### PR TITLE
Graph, Documents, Images

### DIFF
--- a/.idea/libraries/Gradle__androidx_activity_activity_1_8_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_activity_activity_1_8_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.activity:activity:1.8.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/7514265ce68f96b321d2c57e574a3637/transformed/activity-1.8.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/7514265ce68f96b321d2c57e574a3637/transformed/activity-1.8.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/7514265ce68f96b321d2c57e574a3637/transformed/activity-1.8.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7514265ce68f96b321d2c57e574a3637/transformed/activity-1.8.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7514265ce68f96b321d2c57e574a3637/transformed/activity-1.8.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7514265ce68f96b321d2c57e574a3637/transformed/activity-1.8.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.activity/activity/1.8.0/d56176e5b2b55654d898039f3c3685cc9c221af7/activity-1.8.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.activity/activity/1.8.0/d56176e5b2b55654d898039f3c3685cc9c221af7/activity-1.8.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_annotation_annotation_experimental_1_3_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_annotation_annotation_experimental_1_3_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.annotation:annotation-experimental:1.3.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/257a92527395474bea73cee7573cf902/transformed/annotation-experimental-1.3.0/res" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/257a92527395474bea73cee7573cf902/transformed/annotation-experimental-1.3.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/257a92527395474bea73cee7573cf902/transformed/annotation-experimental-1.3.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/257a92527395474bea73cee7573cf902/transformed/annotation-experimental-1.3.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/257a92527395474bea73cee7573cf902/transformed/annotation-experimental-1.3.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/257a92527395474bea73cee7573cf902/transformed/annotation-experimental-1.3.0/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.annotation/annotation-experimental/1.3.0/56ca4da0948c085ca4bb0e6077e01a3ab1298dfb/annotation-experimental-1.3.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.annotation/annotation-experimental/1.3.0/56ca4da0948c085ca4bb0e6077e01a3ab1298dfb/annotation-experimental-1.3.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_annotation_annotation_jvm_1_6_0.xml
+++ b/.idea/libraries/Gradle__androidx_annotation_annotation_jvm_1_6_0.xml
@@ -2,11 +2,11 @@
   <library name="Gradle: androidx.annotation:annotation-jvm:1.6.0" type="java-imported" external-system-id="GRADLE">
     <properties groupId="androidx.annotation" artifactId="annotation-jvm" version="1.6.0" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.annotation/annotation-jvm/1.6.0/a7257339a052df0f91433cf9651231bbb802b502/annotation-jvm-1.6.0.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.annotation/annotation-jvm/1.6.0/a7257339a052df0f91433cf9651231bbb802b502/annotation-jvm-1.6.0.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.annotation/annotation-jvm/1.6.0/407ff5ab230288b9cdabf7223058592370882f1f/annotation-jvm-1.6.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.annotation/annotation-jvm/1.6.0/407ff5ab230288b9cdabf7223058592370882f1f/annotation-jvm-1.6.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_appcompat_appcompat_1_6_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_appcompat_appcompat_1_6_1_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.appcompat:appcompat:1.6.1@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d987c645dfc01a04510c4a57f9eee552/transformed/appcompat-1.6.1/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.appcompat/appcompat/1.6.1/ace9a78b961165396147e8691faa18c1b0e48e20/appcompat-1.6.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.appcompat/appcompat/1.6.1/ace9a78b961165396147e8691faa18c1b0e48e20/appcompat-1.6.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_appcompat_appcompat_resources_1_6_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_appcompat_appcompat_resources_1_6_1_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.appcompat:appcompat-resources:1.6.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/723bd975f41a2a7ce69cac3af41e5540/transformed/appcompat-resources-1.6.1/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/723bd975f41a2a7ce69cac3af41e5540/transformed/appcompat-resources-1.6.1/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/723bd975f41a2a7ce69cac3af41e5540/transformed/appcompat-resources-1.6.1/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/723bd975f41a2a7ce69cac3af41e5540/transformed/appcompat-resources-1.6.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/723bd975f41a2a7ce69cac3af41e5540/transformed/appcompat-resources-1.6.1/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/723bd975f41a2a7ce69cac3af41e5540/transformed/appcompat-resources-1.6.1/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.appcompat/appcompat-resources/1.6.1/53fccb3cf4bae3905a487581fb3ff7b9616583a6/appcompat-resources-1.6.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.appcompat/appcompat-resources/1.6.1/53fccb3cf4bae3905a487581fb3ff7b9616583a6/appcompat-resources-1.6.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_arch_core_core_common_2_2_0.xml
+++ b/.idea/libraries/Gradle__androidx_arch_core_core_common_2_2_0.xml
@@ -2,11 +2,11 @@
   <library name="Gradle: androidx.arch.core:core-common:2.2.0" type="java-imported" external-system-id="GRADLE">
     <properties groupId="androidx.arch.core" artifactId="core-common" version="2.2.0" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.arch.core/core-common/2.2.0/5e1b8b81dfd5f52c56a8d53b18ca759c19a301f3/core-common-2.2.0.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.arch.core/core-common/2.2.0/5e1b8b81dfd5f52c56a8d53b18ca759c19a301f3/core-common-2.2.0.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.arch.core/core-common/2.2.0/f3ac1460fc6844d5441595a34591af7fc04fd2e5/core-common-2.2.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.arch.core/core-common/2.2.0/f3ac1460fc6844d5441595a34591af7fc04fd2e5/core-common-2.2.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_browser_browser_1_4_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_browser_browser_1_4_0_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.browser:browser:1.4.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7db465761980f1215204b6a005d41b17/transformed/browser-1.4.0/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.browser/browser/1.4.0/2a2741f63427dcdb3b6821dd17703bc16ced13a1/browser-1.4.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.browser/browser/1.4.0/2a2741f63427dcdb3b6821dd17703bc16ced13a1/browser-1.4.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_cardview_cardview_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_cardview_cardview_1_0_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.cardview:cardview:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/4a712330a908fb7bbdf375e8810b6632/transformed/cardview-1.0.0/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/4a712330a908fb7bbdf375e8810b6632/transformed/cardview-1.0.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/4a712330a908fb7bbdf375e8810b6632/transformed/cardview-1.0.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/4a712330a908fb7bbdf375e8810b6632/transformed/cardview-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/4a712330a908fb7bbdf375e8810b6632/transformed/cardview-1.0.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/4a712330a908fb7bbdf375e8810b6632/transformed/cardview-1.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.cardview/cardview/1.0.0/c9f3ce7ca74ad2c978230f4094ba6804c5166f9c/cardview-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.cardview/cardview/1.0.0/c9f3ce7ca74ad2c978230f4094ba6804c5166f9c/cardview-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_collection_collection_1_1_0.xml
+++ b/.idea/libraries/Gradle__androidx_collection_collection_1_1_0.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.collection:collection:1.1.0" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/1f27220b47669781457de0d600849a5de0e89909/collection-1.1.0.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/1f27220b47669781457de0d600849a5de0e89909/collection-1.1.0.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/bae67b0019fbb38498198fcc2d0282a340b71c5b/collection-1.1.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/bae67b0019fbb38498198fcc2d0282a340b71c5b/collection-1.1.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_concurrent_concurrent_futures_1_1_0.xml
+++ b/.idea/libraries/Gradle__androidx_concurrent_concurrent_futures_1_1_0.xml
@@ -2,11 +2,11 @@
   <library name="Gradle: androidx.concurrent:concurrent-futures:1.1.0" type="java-imported" external-system-id="GRADLE">
     <properties groupId="androidx.concurrent" artifactId="concurrent-futures" version="1.1.0" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.concurrent/concurrent-futures/1.1.0/50b7fb98350d5f42a4e49704b03278542293ba48/concurrent-futures-1.1.0.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.concurrent/concurrent-futures/1.1.0/50b7fb98350d5f42a4e49704b03278542293ba48/concurrent-futures-1.1.0.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.concurrent/concurrent-futures/1.1.0/a27842adf6c42f3d80893bd46e1de4ac024218e7/concurrent-futures-1.1.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.concurrent/concurrent-futures/1.1.0/a27842adf6c42f3d80893bd46e1de4ac024218e7/concurrent-futures-1.1.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_constraintlayout_constraintlayout_2_1_4_aar.xml
+++ b/.idea/libraries/Gradle__androidx_constraintlayout_constraintlayout_2_1_4_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.constraintlayout:constraintlayout:2.1.4@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/671d9899c0a3bf5879cd9e020dbf8ae2/transformed/constraintlayout-2.1.4/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/671d9899c0a3bf5879cd9e020dbf8ae2/transformed/constraintlayout-2.1.4/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/671d9899c0a3bf5879cd9e020dbf8ae2/transformed/constraintlayout-2.1.4/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/671d9899c0a3bf5879cd9e020dbf8ae2/transformed/constraintlayout-2.1.4/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/671d9899c0a3bf5879cd9e020dbf8ae2/transformed/constraintlayout-2.1.4/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/671d9899c0a3bf5879cd9e020dbf8ae2/transformed/constraintlayout-2.1.4/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.constraintlayout/constraintlayout/2.1.4/27e12209e529970f69bc817f349c247ef238fae7/constraintlayout-2.1.4-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.constraintlayout/constraintlayout/2.1.4/27e12209e529970f69bc817f349c247ef238fae7/constraintlayout-2.1.4-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_coordinatorlayout_coordinatorlayout_1_1_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_coordinatorlayout_coordinatorlayout_1_1_0_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.coordinatorlayout:coordinatorlayout:1.1.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/AndroidManifest.xml" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b2e9295bb5ea2a2c11a0030a826b6c4b/transformed/coordinatorlayout-1.1.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.coordinatorlayout/coordinatorlayout/1.1.0/a15529ac349d76a872ae5ef42b84c320c456cd7f/coordinatorlayout-1.1.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.coordinatorlayout/coordinatorlayout/1.1.0/a15529ac349d76a872ae5ef42b84c320c456cd7f/coordinatorlayout-1.1.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_core_core_1_12_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_core_core_1_12_0_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.core:core:1.12.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/b26299f886ac6c74041df271daeb8cb0/transformed/core-1.12.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.core/core/1.12.0/696658fc9147f9bb2e04c64f77fa0c8a603583d/core-1.12.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.core/core/1.12.0/696658fc9147f9bb2e04c64f77fa0c8a603583d/core-1.12.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_core_core_ktx_1_12_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_core_core_ktx_1_12_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.core:core-ktx:1.12.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/553456e0da0f13ca1830022146f831fa/transformed/core-ktx-1.12.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/553456e0da0f13ca1830022146f831fa/transformed/core-ktx-1.12.0/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/553456e0da0f13ca1830022146f831fa/transformed/core-ktx-1.12.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/553456e0da0f13ca1830022146f831fa/transformed/core-ktx-1.12.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/553456e0da0f13ca1830022146f831fa/transformed/core-ktx-1.12.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/553456e0da0f13ca1830022146f831fa/transformed/core-ktx-1.12.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.core/core-ktx/1.12.0/e6c10584acda1ffeb12bf3bee451bed5ffbe2705/core-ktx-1.12.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.core/core-ktx/1.12.0/e6c10584acda1ffeb12bf3bee451bed5ffbe2705/core-ktx-1.12.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_cursoradapter_cursoradapter_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_cursoradapter_cursoradapter_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.cursoradapter:cursoradapter:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/03cbc252d582c2aebb9e49bf536def35/transformed/cursoradapter-1.0.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/03cbc252d582c2aebb9e49bf536def35/transformed/cursoradapter-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/03cbc252d582c2aebb9e49bf536def35/transformed/cursoradapter-1.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/03cbc252d582c2aebb9e49bf536def35/transformed/cursoradapter-1.0.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.cursoradapter/cursoradapter/1.0.0/1e323083b41c31fd4d45510dfce50614963c3c6c/cursoradapter-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.cursoradapter/cursoradapter/1.0.0/1e323083b41c31fd4d45510dfce50614963c3c6c/cursoradapter-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_customview_customview_1_1_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_customview_customview_1_1_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.customview:customview:1.1.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/9e41c8d080f5ee57430d4a1229ada974/transformed/customview-1.1.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/9e41c8d080f5ee57430d4a1229ada974/transformed/customview-1.1.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/9e41c8d080f5ee57430d4a1229ada974/transformed/customview-1.1.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/9e41c8d080f5ee57430d4a1229ada974/transformed/customview-1.1.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.customview/customview/1.1.0/be631aafb1eb3f64c9cc57083a21a3321cf2e2e1/customview-1.1.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.customview/customview/1.1.0/be631aafb1eb3f64c9cc57083a21a3321cf2e2e1/customview-1.1.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_databinding_viewbinding_8_2_2_aar.xml
+++ b/.idea/libraries/Gradle__androidx_databinding_viewbinding_8_2_2_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.databinding:viewbinding:8.2.2@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/791cfc4f52a51d97155caa5178b9a931/transformed/viewbinding-8.2.2/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/791cfc4f52a51d97155caa5178b9a931/transformed/viewbinding-8.2.2/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/791cfc4f52a51d97155caa5178b9a931/transformed/viewbinding-8.2.2/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/791cfc4f52a51d97155caa5178b9a931/transformed/viewbinding-8.2.2/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.databinding/viewbinding/8.2.2/a113c3e3e636c709323ea47b3b44e4f0b626f511/viewbinding-8.2.2-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.databinding/viewbinding/8.2.2/a113c3e3e636c709323ea47b3b44e4f0b626f511/viewbinding-8.2.2-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_documentfile_documentfile_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_documentfile_documentfile_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.documentfile:documentfile:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/050578227cd1c5d77679f391deae6ab6/transformed/documentfile-1.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/050578227cd1c5d77679f391deae6ab6/transformed/documentfile-1.0.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/050578227cd1c5d77679f391deae6ab6/transformed/documentfile-1.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/050578227cd1c5d77679f391deae6ab6/transformed/documentfile-1.0.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.documentfile/documentfile/1.0.0/a1bed5cf96db96bd06a2feade98fe55653811dc8/documentfile-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.documentfile/documentfile/1.0.0/a1bed5cf96db96bd06a2feade98fe55653811dc8/documentfile-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_drawerlayout_drawerlayout_1_1_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_drawerlayout_drawerlayout_1_1_1_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.drawerlayout:drawerlayout:1.1.1@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5e1aaae8bed9929e59171e0ddf66fffe/transformed/drawerlayout-1.1.1/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.drawerlayout/drawerlayout/1.1.1/d95f7d9cd7d95cc0c038bbcf9c65f521b56fee55/drawerlayout-1.1.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.drawerlayout/drawerlayout/1.1.1/d95f7d9cd7d95cc0c038bbcf9c65f521b56fee55/drawerlayout-1.1.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_dynamicanimation_dynamicanimation_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_dynamicanimation_dynamicanimation_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.dynamicanimation:dynamicanimation:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/8a289912a56f2a3f7f510c6a9fbecb83/transformed/dynamicanimation-1.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/8a289912a56f2a3f7f510c6a9fbecb83/transformed/dynamicanimation-1.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/8a289912a56f2a3f7f510c6a9fbecb83/transformed/dynamicanimation-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/8a289912a56f2a3f7f510c6a9fbecb83/transformed/dynamicanimation-1.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.dynamicanimation/dynamicanimation/1.0.0/5c050e29af5033ff5e2d58ccf657ae92fdfbda4a/dynamicanimation-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.dynamicanimation/dynamicanimation/1.0.0/5c050e29af5033ff5e2d58ccf657ae92fdfbda4a/dynamicanimation-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_fragment_fragment_1_3_6_aar.xml
+++ b/.idea/libraries/Gradle__androidx_fragment_fragment_1_3_6_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.fragment:fragment:1.3.6@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7170f0b1baa93b7a1eb92171fd4f93d4/transformed/fragment-1.3.6/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.fragment/fragment/1.3.6/25ece06338d39da1fdc9d8488aa57b5014866918/fragment-1.3.6-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.fragment/fragment/1.3.6/25ece06338d39da1fdc9d8488aa57b5014866918/fragment-1.3.6-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_interpolator_interpolator_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_interpolator_interpolator_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.interpolator:interpolator:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/40d75de682bb9125b3c92e2cbd8e47d9/transformed/interpolator-1.0.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/40d75de682bb9125b3c92e2cbd8e47d9/transformed/interpolator-1.0.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/40d75de682bb9125b3c92e2cbd8e47d9/transformed/interpolator-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/40d75de682bb9125b3c92e2cbd8e47d9/transformed/interpolator-1.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.interpolator/interpolator/1.0.0/fefd5e3cbc479b6b4a9532d05688a1e659e8d3d2/interpolator-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.interpolator/interpolator/1.0.0/fefd5e3cbc479b6b4a9532d05688a1e659e8d3d2/interpolator-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_legacy_legacy_support_core_utils_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_legacy_legacy_support_core_utils_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.legacy:legacy-support-core-utils:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/81681b09bf1f5ef50f879d7dd3b95a7f/transformed/legacy-support-core-utils-1.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/81681b09bf1f5ef50f879d7dd3b95a7f/transformed/legacy-support-core-utils-1.0.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/81681b09bf1f5ef50f879d7dd3b95a7f/transformed/legacy-support-core-utils-1.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/81681b09bf1f5ef50f879d7dd3b95a7f/transformed/legacy-support-core-utils-1.0.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.legacy/legacy-support-core-utils/1.0.0/46c37f178088153618cfb0afef08ec96c48f93cb/legacy-support-core-utils-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.legacy/legacy-support-core-utils/1.0.0/46c37f178088153618cfb0afef08ec96c48f93cb/legacy-support-core-utils-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_common_2_7_0.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_common_2_7_0.xml
@@ -2,11 +2,11 @@
   <library name="Gradle: androidx.lifecycle:lifecycle-common:2.7.0" type="java-imported" external-system-id="GRADLE">
     <properties groupId="androidx.lifecycle" artifactId="lifecycle-common" version="2.7.0" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-common/2.7.0/85334205d65cca70ed0109c3acbd29e22a2d9cb1/lifecycle-common-2.7.0.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-common/2.7.0/85334205d65cca70ed0109c3acbd29e22a2d9cb1/lifecycle-common-2.7.0.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-common/2.7.0/de4ccde9dba9e5c3454dd325535aab954ebe94bc/lifecycle-common-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-common/2.7.0/de4ccde9dba9e5c3454dd325535aab954ebe94bc/lifecycle-common-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-livedata:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/db9fae2fae3178a1ad474077fc1a7a0b/transformed/lifecycle-livedata-2.7.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/db9fae2fae3178a1ad474077fc1a7a0b/transformed/lifecycle-livedata-2.7.0/AndroidManifest.xml" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/db9fae2fae3178a1ad474077fc1a7a0b/transformed/lifecycle-livedata-2.7.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/db9fae2fae3178a1ad474077fc1a7a0b/transformed/lifecycle-livedata-2.7.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/db9fae2fae3178a1ad474077fc1a7a0b/transformed/lifecycle-livedata-2.7.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/db9fae2fae3178a1ad474077fc1a7a0b/transformed/lifecycle-livedata-2.7.0/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata/2.7.0/e1387f4b1f064cea23c46a1326ea46f37b75a851/lifecycle-livedata-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata/2.7.0/e1387f4b1f064cea23c46a1326ea46f37b75a851/lifecycle-livedata-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_core_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_core_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-livedata-core:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/19a1829d05d92c0cf2a940925126bc52/transformed/lifecycle-livedata-core-2.7.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/19a1829d05d92c0cf2a940925126bc52/transformed/lifecycle-livedata-core-2.7.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/19a1829d05d92c0cf2a940925126bc52/transformed/lifecycle-livedata-core-2.7.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/19a1829d05d92c0cf2a940925126bc52/transformed/lifecycle-livedata-core-2.7.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/19a1829d05d92c0cf2a940925126bc52/transformed/lifecycle-livedata-core-2.7.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/19a1829d05d92c0cf2a940925126bc52/transformed/lifecycle-livedata-core-2.7.0/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata-core/2.7.0/148c40c69e28eb19bdf817bef6e7b0f24bfa51f9/lifecycle-livedata-core-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata-core/2.7.0/148c40c69e28eb19bdf817bef6e7b0f24bfa51f9/lifecycle-livedata-core-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_core_ktx_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_core_ktx_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/bcf36411d004fa3992e0ecdb38563afd/transformed/lifecycle-livedata-core-ktx-2.7.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/bcf36411d004fa3992e0ecdb38563afd/transformed/lifecycle-livedata-core-ktx-2.7.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/bcf36411d004fa3992e0ecdb38563afd/transformed/lifecycle-livedata-core-ktx-2.7.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/bcf36411d004fa3992e0ecdb38563afd/transformed/lifecycle-livedata-core-ktx-2.7.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/bcf36411d004fa3992e0ecdb38563afd/transformed/lifecycle-livedata-core-ktx-2.7.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/bcf36411d004fa3992e0ecdb38563afd/transformed/lifecycle-livedata-core-ktx-2.7.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata-core-ktx/2.7.0/679a0782faddfa90863d19babbe2b44ded7d13b/lifecycle-livedata-core-ktx-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata-core-ktx/2.7.0/679a0782faddfa90863d19babbe2b44ded7d13b/lifecycle-livedata-core-ktx-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_ktx_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_livedata_ktx_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-livedata-ktx:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/5db6d547acb502d8c96489bbbf050351/transformed/lifecycle-livedata-ktx-2.7.0/res" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/5db6d547acb502d8c96489bbbf050351/transformed/lifecycle-livedata-ktx-2.7.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/5db6d547acb502d8c96489bbbf050351/transformed/lifecycle-livedata-ktx-2.7.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5db6d547acb502d8c96489bbbf050351/transformed/lifecycle-livedata-ktx-2.7.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5db6d547acb502d8c96489bbbf050351/transformed/lifecycle-livedata-ktx-2.7.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5db6d547acb502d8c96489bbbf050351/transformed/lifecycle-livedata-ktx-2.7.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata-ktx/2.7.0/2ad14aed781c4a73ed4dbb421966d408a0a06686/lifecycle-livedata-ktx-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-livedata-ktx/2.7.0/2ad14aed781c4a73ed4dbb421966d408a0a06686/lifecycle-livedata-ktx-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_runtime_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_runtime_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-runtime:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/73b183598b6a096c3b58a0cf2b7b4467/transformed/lifecycle-runtime-2.7.0/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/73b183598b6a096c3b58a0cf2b7b4467/transformed/lifecycle-runtime-2.7.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/73b183598b6a096c3b58a0cf2b7b4467/transformed/lifecycle-runtime-2.7.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/73b183598b6a096c3b58a0cf2b7b4467/transformed/lifecycle-runtime-2.7.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/73b183598b6a096c3b58a0cf2b7b4467/transformed/lifecycle-runtime-2.7.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/73b183598b6a096c3b58a0cf2b7b4467/transformed/lifecycle-runtime-2.7.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-runtime/2.7.0/3b9fd825868268670401263d41e09e1ec80a3e23/lifecycle-runtime-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-runtime/2.7.0/3b9fd825868268670401263d41e09e1ec80a3e23/lifecycle-runtime-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_viewmodel_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_viewmodel_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-viewmodel:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/a08c0e6e6fb6d9129f57ef3c2d5bc305/transformed/lifecycle-viewmodel-2.7.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/a08c0e6e6fb6d9129f57ef3c2d5bc305/transformed/lifecycle-viewmodel-2.7.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/a08c0e6e6fb6d9129f57ef3c2d5bc305/transformed/lifecycle-viewmodel-2.7.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a08c0e6e6fb6d9129f57ef3c2d5bc305/transformed/lifecycle-viewmodel-2.7.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a08c0e6e6fb6d9129f57ef3c2d5bc305/transformed/lifecycle-viewmodel-2.7.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a08c0e6e6fb6d9129f57ef3c2d5bc305/transformed/lifecycle-viewmodel-2.7.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-viewmodel/2.7.0/c4f0ffe7a451136f33c07c6c3cab550688b1e819/lifecycle-viewmodel-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-viewmodel/2.7.0/c4f0ffe7a451136f33c07c6c3cab550688b1e819/lifecycle-viewmodel-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_viewmodel_ktx_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_viewmodel_ktx_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/f90f4009573df42e9809619bd6d43d4c/transformed/lifecycle-viewmodel-ktx-2.7.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/f90f4009573df42e9809619bd6d43d4c/transformed/lifecycle-viewmodel-ktx-2.7.0/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/f90f4009573df42e9809619bd6d43d4c/transformed/lifecycle-viewmodel-ktx-2.7.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f90f4009573df42e9809619bd6d43d4c/transformed/lifecycle-viewmodel-ktx-2.7.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f90f4009573df42e9809619bd6d43d4c/transformed/lifecycle-viewmodel-ktx-2.7.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f90f4009573df42e9809619bd6d43d4c/transformed/lifecycle-viewmodel-ktx-2.7.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-viewmodel-ktx/2.7.0/a96d165dc6197241de8dd3a77779d86e3d44e920/lifecycle-viewmodel-ktx-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-viewmodel-ktx/2.7.0/a96d165dc6197241de8dd3a77779d86e3d44e920/lifecycle-viewmodel-ktx-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_viewmodel_savedstate_2_7_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_lifecycle_lifecycle_viewmodel_savedstate_2_7_0_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/dde3cfa1b7a31869aeb4876499975c9e/transformed/lifecycle-viewmodel-savedstate-2.7.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/dde3cfa1b7a31869aeb4876499975c9e/transformed/lifecycle-viewmodel-savedstate-2.7.0/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/dde3cfa1b7a31869aeb4876499975c9e/transformed/lifecycle-viewmodel-savedstate-2.7.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/dde3cfa1b7a31869aeb4876499975c9e/transformed/lifecycle-viewmodel-savedstate-2.7.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/dde3cfa1b7a31869aeb4876499975c9e/transformed/lifecycle-viewmodel-savedstate-2.7.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/dde3cfa1b7a31869aeb4876499975c9e/transformed/lifecycle-viewmodel-savedstate-2.7.0/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-viewmodel-savedstate/2.7.0/cbf132838873372144077f5c6da9502248505d7c/lifecycle-viewmodel-savedstate-2.7.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-viewmodel-savedstate/2.7.0/cbf132838873372144077f5c6da9502248505d7c/lifecycle-viewmodel-savedstate-2.7.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_loader_loader_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_loader_loader_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.loader:loader:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/d787b1446feb5ed8318d00dba538cdb2/transformed/loader-1.0.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/d787b1446feb5ed8318d00dba538cdb2/transformed/loader-1.0.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d787b1446feb5ed8318d00dba538cdb2/transformed/loader-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d787b1446feb5ed8318d00dba538cdb2/transformed/loader-1.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.loader/loader/1.0.0/b9ef587f3e46c7fe5b00264989764e43ff45cada/loader-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.loader/loader/1.0.0/b9ef587f3e46c7fe5b00264989764e43ff45cada/loader-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_localbroadcastmanager_localbroadcastmanager_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_localbroadcastmanager_localbroadcastmanager_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.localbroadcastmanager:localbroadcastmanager:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/65e7b7628b1834ff45433dbe3bb3faf9/transformed/localbroadcastmanager-1.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/65e7b7628b1834ff45433dbe3bb3faf9/transformed/localbroadcastmanager-1.0.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/65e7b7628b1834ff45433dbe3bb3faf9/transformed/localbroadcastmanager-1.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/65e7b7628b1834ff45433dbe3bb3faf9/transformed/localbroadcastmanager-1.0.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.localbroadcastmanager/localbroadcastmanager/1.0.0/3930e99159fd6b7f1d2e7d5fe9af0924ca1faf9/localbroadcastmanager-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.localbroadcastmanager/localbroadcastmanager/1.0.0/3930e99159fd6b7f1d2e7d5fe9af0924ca1faf9/localbroadcastmanager-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_print_print_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_print_print_1_0_0_aar.xml
@@ -1,15 +1,15 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.print:print:1.0.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/ffaefdac1b9bf5064cecc6d30e9d079c/transformed/print-1.0.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/ffaefdac1b9bf5064cecc6d30e9d079c/transformed/print-1.0.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/ffaefdac1b9bf5064cecc6d30e9d079c/transformed/print-1.0.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/ffaefdac1b9bf5064cecc6d30e9d079c/transformed/print-1.0.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/ffaefdac1b9bf5064cecc6d30e9d079c/transformed/print-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/ffaefdac1b9bf5064cecc6d30e9d079c/transformed/print-1.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.print/print/1.0.0/71fc2d9acf7cce6b96230c5af263268b1664914a/print-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.print/print/1.0.0/71fc2d9acf7cce6b96230c5af263268b1664914a/print-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_privacysandbox_ads_ads_adservices_1_0_0_beta05_aar.xml
+++ b/.idea/libraries/Gradle__androidx_privacysandbox_ads_ads_adservices_1_0_0_beta05_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.privacysandbox.ads:ads-adservices:1.0.0-beta05@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/1fab7e556c087587030af2485e7f3cf5/transformed/ads-adservices-1.0.0-beta05/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/1fab7e556c087587030af2485e7f3cf5/transformed/ads-adservices-1.0.0-beta05/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/1fab7e556c087587030af2485e7f3cf5/transformed/ads-adservices-1.0.0-beta05/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/1fab7e556c087587030af2485e7f3cf5/transformed/ads-adservices-1.0.0-beta05/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/1fab7e556c087587030af2485e7f3cf5/transformed/ads-adservices-1.0.0-beta05/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/1fab7e556c087587030af2485e7f3cf5/transformed/ads-adservices-1.0.0-beta05/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.privacysandbox.ads/ads-adservices/1.0.0-beta05/d1bee637614b7927092da068ca8122ab85f3fd05/ads-adservices-1.0.0-beta05-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.privacysandbox.ads/ads-adservices/1.0.0-beta05/d1bee637614b7927092da068ca8122ab85f3fd05/ads-adservices-1.0.0-beta05-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_privacysandbox_ads_ads_adservices_java_1_0_0_beta05_aar.xml
+++ b/.idea/libraries/Gradle__androidx_privacysandbox_ads_ads_adservices_java_1_0_0_beta05_aar.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.privacysandbox.ads:ads-adservices-java:1.0.0-beta05@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/06ca49da59d7d6c18a21abfdc3e92db9/transformed/ads-adservices-java-1.0.0-beta05/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/06ca49da59d7d6c18a21abfdc3e92db9/transformed/ads-adservices-java-1.0.0-beta05/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/06ca49da59d7d6c18a21abfdc3e92db9/transformed/ads-adservices-java-1.0.0-beta05/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/06ca49da59d7d6c18a21abfdc3e92db9/transformed/ads-adservices-java-1.0.0-beta05/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/06ca49da59d7d6c18a21abfdc3e92db9/transformed/ads-adservices-java-1.0.0-beta05/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/06ca49da59d7d6c18a21abfdc3e92db9/transformed/ads-adservices-java-1.0.0-beta05/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.privacysandbox.ads/ads-adservices-java/1.0.0-beta05/cdc9d1fdbc1a4c7ce29c559bf41ed7f07732abdd/ads-adservices-java-1.0.0-beta05-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.privacysandbox.ads/ads-adservices-java/1.0.0-beta05/cdc9d1fdbc1a4c7ce29c559bf41ed7f07732abdd/ads-adservices-java-1.0.0-beta05-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_recyclerview_recyclerview_1_1_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_recyclerview_recyclerview_1_1_0_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.recyclerview:recyclerview:1.1.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/944827a1621dc258008fd111984807d0/transformed/recyclerview-1.1.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.recyclerview/recyclerview/1.1.0/f2bdf79e1977939817f54a9d3e2f6bc52b63bdd0/recyclerview-1.1.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.recyclerview/recyclerview/1.1.0/f2bdf79e1977939817f54a9d3e2f6bc52b63bdd0/recyclerview-1.1.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_resourceinspection_resourceinspection_annotation_1_0_1.xml
+++ b/.idea/libraries/Gradle__androidx_resourceinspection_resourceinspection_annotation_1_0_1.xml
@@ -2,11 +2,11 @@
   <library name="Gradle: androidx.resourceinspection:resourceinspection-annotation:1.0.1" type="java-imported" external-system-id="GRADLE">
     <properties groupId="androidx.resourceinspection" artifactId="resourceinspection-annotation" version="1.0.1" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.resourceinspection/resourceinspection-annotation/1.0.1/8c21f8ff5d96d5d52c948707f7e4d6ca6773feef/resourceinspection-annotation-1.0.1.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.resourceinspection/resourceinspection-annotation/1.0.1/8c21f8ff5d96d5d52c948707f7e4d6ca6773feef/resourceinspection-annotation-1.0.1.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.resourceinspection/resourceinspection-annotation/1.0.1/a1c91a3cf63fd51a8e755747186d97585f955ae3/resourceinspection-annotation-1.0.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.resourceinspection/resourceinspection-annotation/1.0.1/a1c91a3cf63fd51a8e755747186d97585f955ae3/resourceinspection-annotation-1.0.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_annotation_1_0_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_annotation_1_0_1_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test:annotation:1.0.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/135c5749d5647f65b6533a9f7c09fcbf/transformed/annotation-1.0.1/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/135c5749d5647f65b6533a9f7c09fcbf/transformed/annotation-1.0.1/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/135c5749d5647f65b6533a9f7c09fcbf/transformed/annotation-1.0.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/135c5749d5647f65b6533a9f7c09fcbf/transformed/annotation-1.0.1/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test/annotation/1.0.1/d922fcf4c7ae6c3b54012d21e594409c6c6ac156/annotation-1.0.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test/annotation/1.0.1/d922fcf4c7ae6c3b54012d21e594409c6c6ac156/annotation-1.0.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_core_1_5_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_core_1_5_0_aar.xml
@@ -1,15 +1,15 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test:core:1.5.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/3c1f575933dc8e40c55e1b59010461db/transformed/core-1.5.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/3c1f575933dc8e40c55e1b59010461db/transformed/core-1.5.0/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/3c1f575933dc8e40c55e1b59010461db/transformed/core-1.5.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3c1f575933dc8e40c55e1b59010461db/transformed/core-1.5.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3c1f575933dc8e40c55e1b59010461db/transformed/core-1.5.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3c1f575933dc8e40c55e1b59010461db/transformed/core-1.5.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test/core/1.5.0/50a7c88bc23efab4bed11093b47197d11ab3d5a0/core-1.5.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test/core/1.5.0/50a7c88bc23efab4bed11093b47197d11ab3d5a0/core-1.5.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test/core/1.5.0/d4ea5ffd68fc05c1e952467fb884f0d82b44ec3b/core-1.5.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test/core/1.5.0/d4ea5ffd68fc05c1e952467fb884f0d82b44ec3b/core-1.5.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_espresso_espresso_core_3_5_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_espresso_espresso_core_3_5_1_aar.xml
@@ -1,14 +1,14 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test.espresso:espresso-core:3.5.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/c62adb87d79f3e350b52d04a7056cff6/transformed/espresso-core-3.5.1/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/c62adb87d79f3e350b52d04a7056cff6/transformed/espresso-core-3.5.1/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/c62adb87d79f3e350b52d04a7056cff6/transformed/espresso-core-3.5.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/c62adb87d79f3e350b52d04a7056cff6/transformed/espresso-core-3.5.1/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.espresso/espresso-core/3.5.1/5aa814b4dae9b17188d620668107d85e687388de/espresso-core-3.5.1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.espresso/espresso-core/3.5.1/5aa814b4dae9b17188d620668107d85e687388de/espresso-core-3.5.1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.espresso/espresso-core/3.5.1/50bb4dd95e68eb3fdc986995afab6730be477cdb/espresso-core-3.5.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.espresso/espresso-core/3.5.1/50bb4dd95e68eb3fdc986995afab6730be477cdb/espresso-core-3.5.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_espresso_espresso_idling_resource_3_5_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_espresso_espresso_idling_resource_3_5_1_aar.xml
@@ -1,14 +1,14 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test.espresso:espresso-idling-resource:3.5.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/a59ef88cc8e62efa2138f9298429de60/transformed/espresso-idling-resource-3.5.1/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/a59ef88cc8e62efa2138f9298429de60/transformed/espresso-idling-resource-3.5.1/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a59ef88cc8e62efa2138f9298429de60/transformed/espresso-idling-resource-3.5.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a59ef88cc8e62efa2138f9298429de60/transformed/espresso-idling-resource-3.5.1/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.espresso/espresso-idling-resource/3.5.1/331f1323e408dc60d9a8bea1eb40a2aa569f8091/espresso-idling-resource-3.5.1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.espresso/espresso-idling-resource/3.5.1/331f1323e408dc60d9a8bea1eb40a2aa569f8091/espresso-idling-resource-3.5.1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.espresso/espresso-idling-resource/3.5.1/7dd3d807f81bd316fe725ad5ab60f7afdad14607/espresso-idling-resource-3.5.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.espresso/espresso-idling-resource/3.5.1/7dd3d807f81bd316fe725ad5ab60f7afdad14607/espresso-idling-resource-3.5.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_ext_junit_1_1_5_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_ext_junit_1_1_5_aar.xml
@@ -1,14 +1,14 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test.ext:junit:1.1.5@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/36b753436af7c538b0fc828274c55960/transformed/junit-1.1.5/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/36b753436af7c538b0fc828274c55960/transformed/junit-1.1.5/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/36b753436af7c538b0fc828274c55960/transformed/junit-1.1.5/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/36b753436af7c538b0fc828274c55960/transformed/junit-1.1.5/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.ext/junit/1.1.5/ee5294c4eb3c3b3ba1d1b0a347ee5d902b1748ee/junit-1.1.5-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.ext/junit/1.1.5/ee5294c4eb3c3b3ba1d1b0a347ee5d902b1748ee/junit-1.1.5-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.ext/junit/1.1.5/e59336d689cf66c42c13a8505fbd83826163431f/junit-1.1.5-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.ext/junit/1.1.5/e59336d689cf66c42c13a8505fbd83826163431f/junit-1.1.5-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_monitor_1_6_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_monitor_1_6_1_aar.xml
@@ -1,14 +1,14 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test:monitor:1.6.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/d578d363b63ddcf3f8bafdf9ec245a50/transformed/monitor-1.6.1/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/d578d363b63ddcf3f8bafdf9ec245a50/transformed/monitor-1.6.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d578d363b63ddcf3f8bafdf9ec245a50/transformed/monitor-1.6.1/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d578d363b63ddcf3f8bafdf9ec245a50/transformed/monitor-1.6.1/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test/monitor/1.6.1/87046c506f644e8c889827b7a5ab9917c8235a23/monitor-1.6.1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test/monitor/1.6.1/87046c506f644e8c889827b7a5ab9917c8235a23/monitor-1.6.1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test/monitor/1.6.1/1e73d3074dcfe62111deab415fb4232386e74d71/monitor-1.6.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test/monitor/1.6.1/1e73d3074dcfe62111deab415fb4232386e74d71/monitor-1.6.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_runner_1_5_2_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_runner_1_5_2_aar.xml
@@ -1,14 +1,14 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test:runner:1.5.2@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/6822b0d9bd51ec2656ad3de04a914404/transformed/runner-1.5.2/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/6822b0d9bd51ec2656ad3de04a914404/transformed/runner-1.5.2/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/6822b0d9bd51ec2656ad3de04a914404/transformed/runner-1.5.2/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/6822b0d9bd51ec2656ad3de04a914404/transformed/runner-1.5.2/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test/runner/1.5.2/6f61644c4619fe5390973846edfd7704d0db55fd/runner-1.5.2-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test/runner/1.5.2/6f61644c4619fe5390973846edfd7704d0db55fd/runner-1.5.2-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test/runner/1.5.2/afd05fc4f8a8375097741bd497654ccbefd63b89/runner-1.5.2-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test/runner/1.5.2/afd05fc4f8a8375097741bd497654ccbefd63b89/runner-1.5.2-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_test_services_storage_1_4_2_aar.xml
+++ b/.idea/libraries/Gradle__androidx_test_services_storage_1_4_2_aar.xml
@@ -1,14 +1,14 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.test.services:storage:1.4.2@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/ab4bba21ae769fb741edee2a8321bbbd/transformed/storage-1.4.2/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/ab4bba21ae769fb741edee2a8321bbbd/transformed/storage-1.4.2/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/ab4bba21ae769fb741edee2a8321bbbd/transformed/storage-1.4.2/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/ab4bba21ae769fb741edee2a8321bbbd/transformed/storage-1.4.2/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.services/storage/1.4.2/edb6438b0e7e21c66b22184eebdb13cd5167161a/storage-1.4.2-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.services/storage/1.4.2/edb6438b0e7e21c66b22184eebdb13cd5167161a/storage-1.4.2-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.test.services/storage/1.4.2/7653e58ad020a74392900229f15971ffb69d57ea/storage-1.4.2-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.test.services/storage/1.4.2/7653e58ad020a74392900229f15971ffb69d57ea/storage-1.4.2-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_tracing_tracing_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_tracing_tracing_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.tracing:tracing:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/056728dcc4c5ff043d5daff2dacd4422/transformed/tracing-1.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/056728dcc4c5ff043d5daff2dacd4422/transformed/tracing-1.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/056728dcc4c5ff043d5daff2dacd4422/transformed/tracing-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/056728dcc4c5ff043d5daff2dacd4422/transformed/tracing-1.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.tracing/tracing/1.0.0/aa6dafdce323d80a993c5427cf81d5072f023c8c/tracing-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.tracing/tracing/1.0.0/aa6dafdce323d80a993c5427cf81d5072f023c8c/tracing-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_transition_transition_1_2_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_transition_transition_1_2_0_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.transition:transition:1.2.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/AndroidManifest.xml" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/83905cc052d07e5c4ccea5db681070a6/transformed/transition-1.2.0/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.transition/transition/1.2.0/65d2a5dab39f120d3f584fdead252ce81ec7dbee/transition-1.2.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.transition/transition/1.2.0/65d2a5dab39f120d3f584fdead252ce81ec7dbee/transition-1.2.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_vectordrawable_vectordrawable_1_1_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_vectordrawable_vectordrawable_1_1_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.vectordrawable:vectordrawable:1.1.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/da1c829e63260e0b901a14c4b8a18e89/transformed/vectordrawable-1.1.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/da1c829e63260e0b901a14c4b8a18e89/transformed/vectordrawable-1.1.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/da1c829e63260e0b901a14c4b8a18e89/transformed/vectordrawable-1.1.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/da1c829e63260e0b901a14c4b8a18e89/transformed/vectordrawable-1.1.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.vectordrawable/vectordrawable/1.1.0/1e0694477eed874c50c54b547cc3e5a62a57a62b/vectordrawable-1.1.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.vectordrawable/vectordrawable/1.1.0/1e0694477eed874c50c54b547cc3e5a62a57a62b/vectordrawable-1.1.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_vectordrawable_vectordrawable_animated_1_1_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_vectordrawable_vectordrawable_animated_1_1_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.vectordrawable:vectordrawable-animated:1.1.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/fba3e4163c96541c43483799a37075ff/transformed/vectordrawable-animated-1.1.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/fba3e4163c96541c43483799a37075ff/transformed/vectordrawable-animated-1.1.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/fba3e4163c96541c43483799a37075ff/transformed/vectordrawable-animated-1.1.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/fba3e4163c96541c43483799a37075ff/transformed/vectordrawable-animated-1.1.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.vectordrawable/vectordrawable-animated/1.1.0/871a7705cd03bc246947638c712cdd11378233ff/vectordrawable-animated-1.1.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.vectordrawable/vectordrawable-animated/1.1.0/871a7705cd03bc246947638c712cdd11378233ff/vectordrawable-animated-1.1.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_versionedparcelable_versionedparcelable_1_1_1_aar.xml
+++ b/.idea/libraries/Gradle__androidx_versionedparcelable_versionedparcelable_1_1_1_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.versionedparcelable:versionedparcelable:1.1.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/67cf80709cf90db02c32ddf92445c907/transformed/versionedparcelable-1.1.1/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/67cf80709cf90db02c32ddf92445c907/transformed/versionedparcelable-1.1.1/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/67cf80709cf90db02c32ddf92445c907/transformed/versionedparcelable-1.1.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/67cf80709cf90db02c32ddf92445c907/transformed/versionedparcelable-1.1.1/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.versionedparcelable/versionedparcelable/1.1.1/d9085927216387af679d18b6f472bc0fc5c7cc81/versionedparcelable-1.1.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.versionedparcelable/versionedparcelable/1.1.1/d9085927216387af679d18b6f472bc0fc5c7cc81/versionedparcelable-1.1.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_viewpager2_viewpager2_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_viewpager2_viewpager2_1_0_0_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.viewpager2:viewpager2:1.0.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/AndroidManifest.xml" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a14b1b39e9739ab6fa661eb080a42c01/transformed/viewpager2-1.0.0/res" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.viewpager2/viewpager2/1.0.0/3c3569044e6969f1ee5c3aa03b08e6717a2d782f/viewpager2-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.viewpager2/viewpager2/1.0.0/3c3569044e6969f1ee5c3aa03b08e6717a2d782f/viewpager2-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__androidx_viewpager_viewpager_1_0_0_aar.xml
+++ b/.idea/libraries/Gradle__androidx_viewpager_viewpager_1_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: androidx.viewpager:viewpager:1.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/ab21533082d3e3dca0f99dc77838d04c/transformed/viewpager-1.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/ab21533082d3e3dca0f99dc77838d04c/transformed/viewpager-1.0.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/ab21533082d3e3dca0f99dc77838d04c/transformed/viewpager-1.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/ab21533082d3e3dca0f99dc77838d04c/transformed/viewpager-1.0.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/androidx.viewpager/viewpager/1.0.0/db045f92188b9d247d5f556866f8861ab68528f0/viewpager-1.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.viewpager/viewpager/1.0.0/db045f92188b9d247d5f556866f8861ab68528f0/viewpager-1.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_android_gms_play_services_ads_identifier_18_0_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_android_gms_play_services_ads_identifier_18_0_0_aar.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.android.gms:play-services-ads-identifier:18.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/de118733532e04299df13ce0660c7167/transformed/play-services-ads-identifier-18.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/de118733532e04299df13ce0660c7167/transformed/play-services-ads-identifier-18.0.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/de118733532e04299df13ce0660c7167/transformed/play-services-ads-identifier-18.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/de118733532e04299df13ce0660c7167/transformed/play-services-ads-identifier-18.0.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.android.gms/play-services-ads-identifier/18.0.0/71d2e97dbe034b36f64b28491590ec2b2ec324e3/play-services-ads-identifier-18.0.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.android.gms/play-services-ads-identifier/18.0.0/71d2e97dbe034b36f64b28491590ec2b2ec324e3/play-services-ads-identifier-18.0.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_android_gms_play_services_auth_api_phone_17_4_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_android_gms_play_services_auth_api_phone_17_4_0_aar.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.android.gms:play-services-auth-api-phone:17.4.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/8b6c256803872b036b7e3b4484919372/transformed/play-services-auth-api-phone-17.4.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/8b6c256803872b036b7e3b4484919372/transformed/play-services-auth-api-phone-17.4.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/8b6c256803872b036b7e3b4484919372/transformed/play-services-auth-api-phone-17.4.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/8b6c256803872b036b7e3b4484919372/transformed/play-services-auth-api-phone-17.4.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.android.gms/play-services-auth-api-phone/17.4.0/b6b7f35110232b40de7a1374921fcff1eaa864ba/play-services-auth-api-phone-17.4.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.android.gms/play-services-auth-api-phone/17.4.0/b6b7f35110232b40de7a1374921fcff1eaa864ba/play-services-auth-api-phone-17.4.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_android_gms_play_services_base_18_0_1_aar.xml
+++ b/.idea/libraries/Gradle__com_google_android_gms_play_services_base_18_0_1_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.android.gms:play-services-base:18.0.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/018f8895eb8dca0f804384168b6b0fe6/transformed/play-services-base-18.0.1/res" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/018f8895eb8dca0f804384168b6b0fe6/transformed/play-services-base-18.0.1/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/018f8895eb8dca0f804384168b6b0fe6/transformed/play-services-base-18.0.1/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/018f8895eb8dca0f804384168b6b0fe6/transformed/play-services-base-18.0.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/018f8895eb8dca0f804384168b6b0fe6/transformed/play-services-base-18.0.1/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/018f8895eb8dca0f804384168b6b0fe6/transformed/play-services-base-18.0.1/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.android.gms/play-services-base/18.0.1/5c3b2e3ce7819eeff73b937ae37741ad2bd88172/play-services-base-18.0.1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.android.gms/play-services-base/18.0.1/5c3b2e3ce7819eeff73b937ae37741ad2bd88172/play-services-base-18.0.1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_android_gms_play_services_stats_17_0_2_aar.xml
+++ b/.idea/libraries/Gradle__com_google_android_gms_play_services_stats_17_0_2_aar.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.android.gms:play-services-stats:17.0.2@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/e5c7134f6759a62a480e36a0b8a0cbaf/transformed/play-services-stats-17.0.2/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/e5c7134f6759a62a480e36a0b8a0cbaf/transformed/play-services-stats-17.0.2/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/e5c7134f6759a62a480e36a0b8a0cbaf/transformed/play-services-stats-17.0.2/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/e5c7134f6759a62a480e36a0b8a0cbaf/transformed/play-services-stats-17.0.2/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.android.gms/play-services-stats/17.0.2/c0d58b8efa926b2c607984c54fb3d274490badd1/play-services-stats-17.0.2-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.android.gms/play-services-stats/17.0.2/c0d58b8efa926b2c607984c54fb3d274490badd1/play-services-stats-17.0.2-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_android_material_material_1_11_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_android_material_material_1_11_0_aar.xml
@@ -1,16 +1,16 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.android.material:material:1.11.0@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/res" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/res" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3a54be033744aa9db692e5e213b928a4/transformed/material-1.11.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.android.material/material/1.11.0/47456a5ab79e72baca757532823ea1fa08e001d3/material-1.11.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.android.material/material/1.11.0/47456a5ab79e72baca757532823ea1fa08e001d3/material-1.11.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_android_play_integrity_1_2_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_android_play_integrity_1_2_0_aar.xml
@@ -1,8 +1,8 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.android.play:integrity:1.2.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/0464a7551f29a3656d35424a01bf478a/transformed/integrity-1.2.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/0464a7551f29a3656d35424a01bf478a/transformed/integrity-1.2.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/0464a7551f29a3656d35424a01bf478a/transformed/integrity-1.2.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/0464a7551f29a3656d35424a01bf478a/transformed/integrity-1.2.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/.idea/libraries/Gradle__com_google_android_recaptcha_recaptcha_18_4_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_android_recaptcha_recaptcha_18_4_0_aar.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.android.recaptcha:recaptcha:18.4.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/2cafb68be2106501d92721ac181c6da3/transformed/recaptcha-18.4.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/2cafb68be2106501d92721ac181c6da3/transformed/recaptcha-18.4.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/2cafb68be2106501d92721ac181c6da3/transformed/recaptcha-18.4.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/2cafb68be2106501d92721ac181c6da3/transformed/recaptcha-18.4.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.android.recaptcha/recaptcha/18.4.0/8c398beffb12445e2bbad52bb615dd43a7d2a01a/recaptcha-18.4.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.android.recaptcha/recaptcha/18.4.0/8c398beffb12445e2bbad52bb615dd43a7d2a01a/recaptcha-18.4.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_code_findbugs_jsr305_3_0_2.xml
+++ b/.idea/libraries/Gradle__com_google_code_findbugs_jsr305_3_0_2.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: com.google.code.findbugs:jsr305:3.0.2" type="java-imported" external-system-id="GRADLE">
     <properties groupId="com.google.code.findbugs" artifactId="jsr305" version="3.0.2" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/7cb5b4e91eb0741882c8fefb2fd0338eff9857c/jsr305-3.0.2-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/7cb5b4e91eb0741882c8fefb2fd0338eff9857c/jsr305-3.0.2-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/b19b5927c2c25b6c70f093767041e641ae0b1b35/jsr305-3.0.2-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/b19b5927c2c25b6c70f093767041e641ae0b1b35/jsr305-3.0.2-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_annotations_16_2_0.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_annotations_16_2_0.xml
@@ -2,10 +2,10 @@
   <library name="Gradle: com.google.firebase:firebase-annotations:16.2.0" type="java-imported" external-system-id="GRADLE">
     <properties groupId="com.google.firebase" artifactId="firebase-annotations" version="16.2.0" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-annotations/16.2.0/ba0806703ca285d03fa9c888b5868f101134a501/firebase-annotations-16.2.0.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-annotations/16.2.0/ba0806703ca285d03fa9c888b5868f101134a501/firebase-annotations-16.2.0.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-annotations/16.2.0/b7d64a22fc61d3a469609c7a1dd3e3d224ad9254/firebase-annotations-16.2.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-annotations/16.2.0/b7d64a22fc61d3a469609c7a1dd3e3d224ad9254/firebase-annotations-16.2.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_appcheck_interop_17_0_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_appcheck_interop_17_0_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.firebase:firebase-appcheck-interop:17.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/3bdf7899cd7127d676491c0df5c314c2/transformed/firebase-appcheck-interop-17.0.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/3bdf7899cd7127d676491c0df5c314c2/transformed/firebase-appcheck-interop-17.0.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3bdf7899cd7127d676491c0df5c314c2/transformed/firebase-appcheck-interop-17.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3bdf7899cd7127d676491c0df5c314c2/transformed/firebase-appcheck-interop-17.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-appcheck-interop/17.0.0/701273a42de5e0b4a6943611ebf1c2b84dc7504d/firebase-appcheck-interop-17.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-appcheck-interop/17.0.0/701273a42de5e0b4a6943611ebf1c2b84dc7504d/firebase-appcheck-interop-17.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_auth_22_3_1_aar.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_auth_22_3_1_aar.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.firebase:firebase-auth:22.3.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/5f45bd76e1c446bebed74eaf12035333/transformed/firebase-auth-22.3.1/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/5f45bd76e1c446bebed74eaf12035333/transformed/firebase-auth-22.3.1/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5f45bd76e1c446bebed74eaf12035333/transformed/firebase-auth-22.3.1/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5f45bd76e1c446bebed74eaf12035333/transformed/firebase-auth-22.3.1/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-auth/22.3.1/9701c8ba9860d4772c35403e31ba64dc620feeaf/firebase-auth-22.3.1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-auth/22.3.1/9701c8ba9860d4772c35403e31ba64dc620feeaf/firebase-auth-22.3.1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_auth_interop_20_0_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_auth_interop_20_0_0_aar.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.firebase:firebase-auth-interop:20.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/f8f647cff54db5ef8f9846fc7d57a052/transformed/firebase-auth-interop-20.0.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/f8f647cff54db5ef8f9846fc7d57a052/transformed/firebase-auth-interop-20.0.0/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f8f647cff54db5ef8f9846fc7d57a052/transformed/firebase-auth-interop-20.0.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f8f647cff54db5ef8f9846fc7d57a052/transformed/firebase-auth-interop-20.0.0/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-auth-interop/20.0.0/8014b3cbc53e9c14226052dd919055a99d0d46d8/firebase-auth-interop-20.0.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-auth-interop/20.0.0/8014b3cbc53e9c14226052dd919055a99d0d46d8/firebase-auth-interop-20.0.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_components_17_1_5_aar.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_components_17_1_5_aar.xml
@@ -1,15 +1,15 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.firebase:firebase-components:17.1.5@aar" external-system-id="GRADLE">
     <ANNOTATIONS>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/5a37156441980a818d9113590daaef44/transformed/firebase-components-17.1.5/annotations.zip!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5a37156441980a818d9113590daaef44/transformed/firebase-components-17.1.5/annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/5a37156441980a818d9113590daaef44/transformed/firebase-components-17.1.5/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/5a37156441980a818d9113590daaef44/transformed/firebase-components-17.1.5/AndroidManifest.xml" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5a37156441980a818d9113590daaef44/transformed/firebase-components-17.1.5/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/5a37156441980a818d9113590daaef44/transformed/firebase-components-17.1.5/jars/classes.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-components/17.1.5/e07e1ac4aa617876a7d23803691dce2422a63078/firebase-components-17.1.5-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-components/17.1.5/e07e1ac4aa617876a7d23803691dce2422a63078/firebase-components-17.1.5-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_installations_17_2_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_installations_17_2_0_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.firebase:firebase-installations:17.2.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/bad89773c6cb38363f354e3df36f89f3/transformed/firebase-installations-17.2.0/jars/classes.jar!/" />
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/bad89773c6cb38363f354e3df36f89f3/transformed/firebase-installations-17.2.0/AndroidManifest.xml" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/bad89773c6cb38363f354e3df36f89f3/transformed/firebase-installations-17.2.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/bad89773c6cb38363f354e3df36f89f3/transformed/firebase-installations-17.2.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-installations/17.2.0/b50e869db1771bfac668d6871ca0db9307450648/firebase-installations-17.2.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-installations/17.2.0/b50e869db1771bfac668d6871ca0db9307450648/firebase-installations-17.2.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_installations_interop_17_1_1_aar.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_installations_interop_17_1_1_aar.xml
@@ -1,12 +1,12 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.firebase:firebase-installations-interop:17.1.1@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/d6e6a6941bf39f18239f57128429749d/transformed/firebase-installations-interop-17.1.1/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/d6e6a6941bf39f18239f57128429749d/transformed/firebase-installations-interop-17.1.1/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d6e6a6941bf39f18239f57128429749d/transformed/firebase-installations-interop-17.1.1/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/d6e6a6941bf39f18239f57128429749d/transformed/firebase-installations-interop-17.1.1/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-installations-interop/17.1.1/2ecad397e77c31bd73c03c866dea1c88831dfd90/firebase-installations-interop-17.1.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-installations-interop/17.1.1/2ecad397e77c31bd73c03c866dea1c88831dfd90/firebase-installations-interop-17.1.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_firebase_firebase_measurement_connector_19_0_0_aar.xml
+++ b/.idea/libraries/Gradle__com_google_firebase_firebase_measurement_connector_19_0_0_aar.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle: com.google.firebase:firebase-measurement-connector:19.0.0@aar" external-system-id="GRADLE">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/caches/transforms-3/7b378f89fba38d67af9f5dd299487034/transformed/firebase-measurement-connector-19.0.0/AndroidManifest.xml" />
-      <root url="jar://$PROJECT_DIR$/caches/transforms-3/7b378f89fba38d67af9f5dd299487034/transformed/firebase-measurement-connector-19.0.0/jars/classes.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7b378f89fba38d67af9f5dd299487034/transformed/firebase-measurement-connector-19.0.0/jars/classes.jar!/" />
+      <root url="file://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7b378f89fba38d67af9f5dd299487034/transformed/firebase-measurement-connector-19.0.0/AndroidManifest.xml" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.firebase/firebase-measurement-connector/19.0.0/c0d58b8efa926b2c607984c54fb3d274490badd1/firebase-measurement-connector-19.0.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-measurement-connector/19.0.0/c0d58b8efa926b2c607984c54fb3d274490badd1/firebase-measurement-connector-19.0.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES />
   </library>

--- a/.idea/libraries/Gradle__com_google_guava_failureaccess_1_0_1.xml
+++ b/.idea/libraries/Gradle__com_google_guava_failureaccess_1_0_1.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: com.google.guava:failureaccess:1.0.1" type="java-imported" external-system-id="GRADLE">
     <properties groupId="com.google.guava" artifactId="failureaccess" version="1.0.1" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/a9aadb2d577ff54ba3115ee7357cbe65bd2a470f/failureaccess-1.0.1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/a9aadb2d577ff54ba3115ee7357cbe65bd2a470f/failureaccess-1.0.1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1d064e61aad6c51cc77f9b59dc2cccc78e792f5a/failureaccess-1.0.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1d064e61aad6c51cc77f9b59dc2cccc78e792f5a/failureaccess-1.0.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava.xml
+++ b/.idea/libraries/Gradle__com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava.xml
@@ -2,7 +2,7 @@
   <library name="Gradle: com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava" type="java-imported" external-system-id="GRADLE">
     <properties groupId="com.google.guava" artifactId="listenablefuture" version="9999.0-empty-to-avoid-conflict-with-guava" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/b421526c5f297295adef1c886e5246c39d4ac629/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/b421526c5f297295adef1c886e5246c39d4ac629/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/.idea/libraries/Gradle__com_squareup_javawriter_2_1_1.xml
+++ b/.idea/libraries/Gradle__com_squareup_javawriter_2_1_1.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: com.squareup:javawriter:2.1.1" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.squareup/javawriter/2.1.1/67ff45d9ae02e583d0f9b3432a5ebbe05c30c966/javawriter-2.1.1.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.squareup/javawriter/2.1.1/67ff45d9ae02e583d0f9b3432a5ebbe05c30c966/javawriter-2.1.1.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.squareup/javawriter/2.1.1/f591a105db78771d0a1e7a277b3747556c528c22/javawriter-2.1.1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.squareup/javawriter/2.1.1/f591a105db78771d0a1e7a277b3747556c528c22/javawriter-2.1.1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/com.squareup/javawriter/2.1.1/5b31387d839a5cdaf5b6de3990da01f7f2b963c5/javawriter-2.1.1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.squareup/javawriter/2.1.1/5b31387d839a5cdaf5b6de3990da01f7f2b963c5/javawriter-2.1.1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__javax_inject_javax_inject_1.xml
+++ b/.idea/libraries/Gradle__javax_inject_javax_inject_1.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: javax.inject:javax.inject:1" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/javax.inject/javax.inject/1/70ec961c25111ed9015d1af77772d96383c2d238/javax.inject-1-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/70ec961c25111ed9015d1af77772d96383c2d238/javax.inject-1-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/javax.inject/javax.inject/1/a00123f261762a7c5e0ec916a2c7c8298d29c400/javax.inject-1-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/a00123f261762a7c5e0ec916a2c7c8298d29c400/javax.inject-1-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__junit_junit_4_13_2.xml
+++ b/.idea/libraries/Gradle__junit_junit_4_13_2.xml
@@ -4,13 +4,13 @@
       <root url="jar://$USER_HOME$/.m2/repository/org/jetbrains/externalAnnotations/junit/junit/4.12-an1/junit-4.12-an1-annotations.zip!/" />
     </ANNOTATIONS>
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/junit/junit/4.13.2/8ac9e16d933b6fb43bc7f576336b8f4d7eb5ba12/junit-4.13.2.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/junit/junit/4.13.2/8ac9e16d933b6fb43bc7f576336b8f4d7eb5ba12/junit-4.13.2.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/junit/junit/4.13.2/f2f3f384dacd2ade2ddf7aa7e0f4360dfee38672/junit-4.13.2-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/junit/junit/4.13.2/f2f3f384dacd2ade2ddf7aa7e0f4360dfee38672/junit-4.13.2-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/junit/junit/4.13.2/33987872a811fe4d4001ed494b07854822257f42/junit-4.13.2-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/junit/junit/4.13.2/33987872a811fe4d4001ed494b07854822257f42/junit-4.13.2-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_hamcrest_hamcrest_core_1_3.xml
+++ b/.idea/libraries/Gradle__org_hamcrest_hamcrest_core_1_3.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: org.hamcrest:hamcrest-core:1.3" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/42a25dc3219429f0e5d060061f71acb49bf010a0/hamcrest-core-1.3.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/42a25dc3219429f0e5d060061f71acb49bf010a0/hamcrest-core-1.3.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/ad09811315f1d4f5756986575b0ea16b99cd686f/hamcrest-core-1.3-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/ad09811315f1d4f5756986575b0ea16b99cd686f/hamcrest-core-1.3-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b/hamcrest-core-1.3-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-core/1.3/1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b/hamcrest-core-1.3-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_hamcrest_hamcrest_integration_1_3.xml
+++ b/.idea/libraries/Gradle__org_hamcrest_hamcrest_integration_1_3.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: org.hamcrest:hamcrest-integration:1.3" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-integration/1.3/5de0c73fef18917cd85d0ab70bb23818685e4dfd/hamcrest-integration-1.3.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-integration/1.3/5de0c73fef18917cd85d0ab70bb23818685e4dfd/hamcrest-integration-1.3.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-integration/1.3/cc5884d4138d3376f574f6a3992acceedfc37bea/hamcrest-integration-1.3-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-integration/1.3/cc5884d4138d3376f574f6a3992acceedfc37bea/hamcrest-integration-1.3-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-integration/1.3/ae7787a563e6a1b1f17fd4ac43be3a3c8830cfda/hamcrest-integration-1.3-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-integration/1.3/ae7787a563e6a1b1f17fd4ac43be3a3c8830cfda/hamcrest-integration-1.3-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_hamcrest_hamcrest_library_1_3.xml
+++ b/.idea/libraries/Gradle__org_hamcrest_hamcrest_library_1_3.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: org.hamcrest:hamcrest-library:1.3" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-library/1.3/4785a3c21320980282f9f33d0d1264a69040538f/hamcrest-library-1.3.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-library/1.3/4785a3c21320980282f9f33d0d1264a69040538f/hamcrest-library-1.3.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-library/1.3/4324046c5f99f3dc91b5370899fa3ae65fd137d2/hamcrest-library-1.3-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-library/1.3/4324046c5f99f3dc91b5370899fa3ae65fd137d2/hamcrest-library-1.3-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.hamcrest/hamcrest-library/1.3/47a7ee46628ab7133129cd7cef1e92657bc275e/hamcrest-library-1.3-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.hamcrest/hamcrest-library/1.3/47a7ee46628ab7133129cd7cef1e92657bc275e/hamcrest-library-1.3-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_annotations_23_0_0.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_annotations_23_0_0.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains:annotations:23.0.0" type="java-imported" external-system-id="GRADLE">
     <properties groupId="org.jetbrains" artifactId="annotations" version="23.0.0" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains/annotations/23.0.0/8cc20c07506ec18e0834947b84a864bfc094484e/annotations-23.0.0.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/23.0.0/8cc20c07506ec18e0834947b84a864bfc094484e/annotations-23.0.0.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains/annotations/23.0.0/41442a550d78cb59a601c1d38603f6ab5497f93c/annotations-23.0.0-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/23.0.0/41442a550d78cb59a601c1d38603f6ab5497f93c/annotations-23.0.0-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains/annotations/23.0.0/ca5088d615accaabd2aa956b10b236a4e75cfccb/annotations-23.0.0-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/23.0.0/ca5088d615accaabd2aa956b10b236a4e75cfccb/annotations-23.0.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_1_8_22.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_1_8_22.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.8.22" type="java-imported" external-system-id="GRADLE">
     <properties groupId="org.jetbrains.kotlin" artifactId="kotlin-stdlib" version="1.8.22" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.22/636bf8b320e7627482771bbac9ed7246773c02bd/kotlin-stdlib-1.8.22.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.22/636bf8b320e7627482771bbac9ed7246773c02bd/kotlin-stdlib-1.8.22.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-1.8.22-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-1.8.22-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.22/6a8d4dfebb88f951bcd9f58636f085bf24ff3e8b/kotlin-stdlib-1.8.22-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.22/6a8d4dfebb88f951bcd9f58636f085bf24ff3e8b/kotlin-stdlib-1.8.22-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_common_1_8_22.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_common_1_8_22.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22" type="kotlin.common" external-system-id="GRADLE">
     <properties groupId="org.jetbrains.kotlin" artifactId="kotlin-stdlib-common" version="1.8.22" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22/1a8e3601703ae14bb58757ea6b2d8e8e5935a586/kotlin-stdlib-common-1.8.22.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22/1a8e3601703ae14bb58757ea6b2d8e8e5935a586/kotlin-stdlib-common-1.8.22.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-common-1.8.22-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-common-1.8.22-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22/ae313b979b8e620a6497cd323f9c5861f7aebef/kotlin-stdlib-common-1.8.22-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22/ae313b979b8e620a6497cd323f9c5861f7aebef/kotlin-stdlib-common-1.8.22-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk7_1_8_20.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk7_1_8_20.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.20" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.20/3aa51faf20aae8b31e1a4bc54f8370673d7b7df4/kotlin-stdlib-jdk7-1.8.20.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.20/3aa51faf20aae8b31e1a4bc54f8370673d7b7df4/kotlin-stdlib-jdk7-1.8.20.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.20/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk7-1.8.20-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.20/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk7-1.8.20-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.20/3641d7cb7650db9fe93a5361b1b88cbcefdb01e0/kotlin-stdlib-jdk7-1.8.20-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.20/3641d7cb7650db9fe93a5361b1b88cbcefdb01e0/kotlin-stdlib-jdk7-1.8.20-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk7_1_8_22.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk7_1_8_22.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22" type="java-imported" external-system-id="GRADLE">
     <properties groupId="org.jetbrains.kotlin" artifactId="kotlin-stdlib-jdk7" version="1.8.22" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.22/4dabb8248310d833bb6a8b516024a91fd3d275c/kotlin-stdlib-jdk7-1.8.22.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.22/4dabb8248310d833bb6a8b516024a91fd3d275c/kotlin-stdlib-jdk7-1.8.22.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk7-1.8.22-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk7-1.8.22-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.22/3641d7cb7650db9fe93a5361b1b88cbcefdb01e0/kotlin-stdlib-jdk7-1.8.22-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.22/3641d7cb7650db9fe93a5361b1b88cbcefdb01e0/kotlin-stdlib-jdk7-1.8.22-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk8_1_8_20.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk8_1_8_20.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20" external-system-id="GRADLE">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.20/73576ddf378c5b4f1f6b449fe6b119b8183fc078/kotlin-stdlib-jdk8-1.8.20.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.20/73576ddf378c5b4f1f6b449fe6b119b8183fc078/kotlin-stdlib-jdk8-1.8.20.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.20/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk8-1.8.20-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.20/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk8-1.8.20-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.20/20739e7aae2a2bfb66c4081b233ffea7b947cf77/kotlin-stdlib-jdk8-1.8.20-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.20/20739e7aae2a2bfb66c4081b233ffea7b947cf77/kotlin-stdlib-jdk8-1.8.20-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk8_1_8_22.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_jdk8_1_8_22.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22" type="java-imported" external-system-id="GRADLE">
     <properties groupId="org.jetbrains.kotlin" artifactId="kotlin-stdlib-jdk8" version="1.8.22" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.22/b25c86d47d6b962b9cf0f8c3f320c8a10eea3dd1/kotlin-stdlib-jdk8-1.8.22.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.22/b25c86d47d6b962b9cf0f8c3f320c8a10eea3dd1/kotlin-stdlib-jdk8-1.8.22.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk8-1.8.22-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.22/5b8f86fea035328fc9e8c660773037a3401ce25f/kotlin-stdlib-jdk8-1.8.22-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.22/20739e7aae2a2bfb66c4081b233ffea7b947cf77/kotlin-stdlib-jdk8-1.8.22-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.22/20739e7aae2a2bfb66c4081b233ffea7b947cf77/kotlin-stdlib-jdk8-1.8.22-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlinx_kotlinx_coroutines_android_1_7_3.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlinx_kotlinx_coroutines_android_1_7_3.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3" type="java-imported" external-system-id="GRADLE">
     <properties groupId="org.jetbrains.kotlinx" artifactId="kotlinx-coroutines-android" version="1.7.3" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-android/1.7.3/38d9cad3a0b03a10453b56577984bdeb48edeed5/kotlinx-coroutines-android-1.7.3.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-android/1.7.3/38d9cad3a0b03a10453b56577984bdeb48edeed5/kotlinx-coroutines-android-1.7.3.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-android/1.7.3/aff10058d69fab68c9b2434510a22ad78cbc0984/kotlinx-coroutines-android-1.7.3-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-android/1.7.3/aff10058d69fab68c9b2434510a22ad78cbc0984/kotlinx-coroutines-android-1.7.3-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-android/1.7.3/3aeb4365c53ed4e61a9caf0778c108352f23507b/kotlinx-coroutines-android-1.7.3-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-android/1.7.3/3aeb4365c53ed4e61a9caf0778c108352f23507b/kotlinx-coroutines-android-1.7.3-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm_1_7_3.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm_1_7_3.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3" type="java-imported" external-system-id="GRADLE">
     <properties groupId="org.jetbrains.kotlinx" artifactId="kotlinx-coroutines-core-jvm" version="1.7.3" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.7.3/2b09627576f0989a436a00a4a54b55fa5026fb86/kotlinx-coroutines-core-jvm-1.7.3.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.7.3/2b09627576f0989a436a00a4a54b55fa5026fb86/kotlinx-coroutines-core-jvm-1.7.3.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.7.3/591a8d2fceb04d6b052d6d29b54c727f97002d82/kotlinx-coroutines-core-jvm-1.7.3-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.7.3/591a8d2fceb04d6b052d6d29b54c727f97002d82/kotlinx-coroutines-core-jvm-1.7.3-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.7.3/b03b58f746a4fbf264c9e63f6b35c4f13ec467f4/kotlinx-coroutines-core-jvm-1.7.3-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.7.3/b03b58f746a4fbf264c9e63f6b35c4f13ec467f4/kotlinx-coroutines-core-jvm-1.7.3-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlinx_kotlinx_coroutines_play_services_1_7_3.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlinx_kotlinx_coroutines_play_services_1_7_3.xml
@@ -2,13 +2,13 @@
   <library name="Gradle: org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3" type="java-imported" external-system-id="GRADLE">
     <properties groupId="org.jetbrains.kotlinx" artifactId="kotlinx-coroutines-play-services" version="1.7.3" />
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-play-services/1.7.3/7087d47913cfb0062c9909dacbfc78fe44c5ecff/kotlinx-coroutines-play-services-1.7.3.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-play-services/1.7.3/7087d47913cfb0062c9909dacbfc78fe44c5ecff/kotlinx-coroutines-play-services-1.7.3.jar!/" />
     </CLASSES>
     <JAVADOC>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-play-services/1.7.3/5f054b27fb6a04b1213a4093e23f7484bd8e9bd/kotlinx-coroutines-play-services-1.7.3-javadoc.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-play-services/1.7.3/5f054b27fb6a04b1213a4093e23f7484bd8e9bd/kotlinx-coroutines-play-services-1.7.3-javadoc.jar!/" />
     </JAVADOC>
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-play-services/1.7.3/e08b1582961acc8e0f8dceb7922217e818692a93/kotlinx-coroutines-play-services-1.7.3-sources.jar!/" />
+      <root url="jar://$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-play-services/1.7.3/e08b1582961acc8e0f8dceb7922217e818692a93/kotlinx-coroutines-play-services-1.7.3-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/modules/app/Fire.app.androidTest.iml
+++ b/.idea/modules/app/Fire.app.androidTest.iml
@@ -38,6 +38,7 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/916636a47deeb28de6003366496bb56d/transformed/firebase-common-ktx-20.4.3-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/c335fcb578d570b3c6ca0ca4e6be2ce3/transformed/material-1.11.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7beb2aed6497dc96efbf238f79154e02/transformed/appcompat-1.6.1-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/00ad3e956d33fc23225686917cab2a1a/transformed/glide-4.12.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/417108bf9d9d7a28bcc7adc3689c0517/transformed/viewpager2-1.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f352bce2f37159593eeef06447a71fe2/transformed/play-services-measurement-21.6.1-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/9e71b40870b29a029f5bc6981e5f46e2/transformed/play-services-measurement-sdk-21.6.1-api.jar</arg>
@@ -105,6 +106,8 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/a571980009a6df9e6b4a3a0bb0ee7138/transformed/cardview-1.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/122b951ff9afa2480c955dd2b0a97791/transformed/localbroadcastmanager-1.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/050daf9a7b0da4434ddf3f0373553b05/transformed/firebase-components-17.1.5-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/02287308a02fccbc0d63129d165d8f17/transformed/gifdecoder-4.12.0-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/49d9df8b8d05db1d51ac97f38f25ce96/transformed/exifinterface-1.2.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.concurrent/concurrent-futures/1.1.0/50b7fb98350d5f42a4e49704b03278542293ba48/concurrent-futures-1.1.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3d2363493bd9cf1eff72f853a147a9d6/transformed/versionedparcelable-1.1.1-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/1f27220b47669781457de0d600849a5de0e89909/collection-1.1.0.jar</arg>
@@ -135,6 +138,8 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.firebase/firebase-annotations/16.2.0/ba0806703ca285d03fa9c888b5868f101134a501/firebase-annotations-16.2.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.resourceinspection/resourceinspection-annotation/1.0.1/8c21f8ff5d96d5d52c948707f7e4d6ca6773feef/resourceinspection-annotation-1.0.1.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.github.bumptech.glide/disklrucache/4.12.0/6d44c9103551e3ff51f00ac26077c143a8fb74f9/disklrucache-4.12.0.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.github.bumptech.glide/annotations/4.12.0/298d793db124809d74ad9a90de5eddc408898c84/annotations-4.12.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.18.0/89b684257096f548fa39a7df9fdaa409d4d4df91/error_prone_annotations-2.18.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3901f4fa07ea3c00c2c1e736209f9f83/transformed/protolite-well-known-types-18.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar</arg>
@@ -259,6 +264,9 @@
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.lifecycle:lifecycle-livedata-ktx:2.7.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.github.PhilJay:MPAndroidChart:v3.1.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:glide:4.12.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:gifdecoder:4.12.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.exifinterface:exifinterface:1.2.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.13.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.annotation:annotation-jvm:1.6.0" level="project" />
@@ -293,6 +301,8 @@
     <orderEntry type="library" scope="TEST" name="Gradle: io.grpc:grpc-protobuf-lite:1.57.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.google.protobuf:protobuf-javalite:3.22.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: io.grpc:grpc-stub:1.57.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:disklrucache:4.12.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:annotations:4.12.0" level="project" />
   </component>
   <component name="TestModuleProperties" production-module="Fire.app.main" />
 </module>

--- a/.idea/modules/app/Fire.app.main.iml
+++ b/.idea/modules/app/Fire.app.main.iml
@@ -25,6 +25,7 @@
           <stringArguments>
             <stringArg name="classpath">
               <args>
+                <arg>$MODULE_DIR$/../../../app/build/intermediates/compile_and_runtime_not_namespaced_r_class_jar/debug/R.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/26ee284f0d785bc799c033095622bd4f/transformed/viewbinding-8.2.2-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/2e6aabd2efec891653a5025d2f4191ca/transformed/firebase-firestore-ktx-24.11.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/741112277b4af0f9dd5ca454ad1b5eec/transformed/firebase-auth-22.3.1-api.jar</arg>
@@ -35,6 +36,7 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/916636a47deeb28de6003366496bb56d/transformed/firebase-common-ktx-20.4.3-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/c335fcb578d570b3c6ca0ca4e6be2ce3/transformed/material-1.11.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7beb2aed6497dc96efbf238f79154e02/transformed/appcompat-1.6.1-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/00ad3e956d33fc23225686917cab2a1a/transformed/glide-4.12.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/417108bf9d9d7a28bcc7adc3689c0517/transformed/viewpager2-1.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f352bce2f37159593eeef06447a71fe2/transformed/play-services-measurement-21.6.1-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/9e71b40870b29a029f5bc6981e5f46e2/transformed/play-services-measurement-sdk-21.6.1-api.jar</arg>
@@ -94,6 +96,8 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/1f27220b47669781457de0d600849a5de0e89909/collection-1.1.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/122b951ff9afa2480c955dd2b0a97791/transformed/localbroadcastmanager-1.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/050daf9a7b0da4434ddf3f0373553b05/transformed/firebase-components-17.1.5-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/02287308a02fccbc0d63129d165d8f17/transformed/gifdecoder-4.12.0-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/49d9df8b8d05db1d51ac97f38f25ce96/transformed/exifinterface-1.2.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/8a3c38cf265786e10ae8ff6aa1a8f7f7/transformed/core-runtime-2.2.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.arch.core/core-common/2.2.0/5e1b8b81dfd5f52c56a8d53b18ca759c19a301f3/core-common-2.2.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.concurrent/concurrent-futures/1.1.0/50b7fb98350d5f42a4e49704b03278542293ba48/concurrent-futures-1.1.0.jar</arg>
@@ -126,6 +130,8 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3901f4fa07ea3c00c2c1e736209f9f83/transformed/protolite-well-known-types-18.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.protobuf/protobuf-javalite/3.22.3/7df7200bce0ff77dc66dd063df79ff74c6114bfc/protobuf-javalite-3.22.3.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/200e7393c4dff4442effbe24428e72a4/transformed/MPAndroidChart-v3.1.0-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.github.bumptech.glide/disklrucache/4.12.0/6d44c9103551e3ff51f00ac26077c143a8fb74f9/disklrucache-4.12.0.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.github.bumptech.glide/annotations/4.12.0/298d793db124809d74ad9a90de5eddc408898c84/annotations-4.12.0.jar</arg>
                 <arg>$USER_HOME$/AppData/Local/Android/Sdk/platforms/android-34/android.jar</arg>
                 <arg>$USER_HOME$/AppData/Local/Android/Sdk/build-tools/34.0.0/core-lambda-stubs.jar</arg>
               </args>
@@ -235,6 +241,9 @@
     <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata-ktx:2.7.0@aar" level="project" />
     <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0@aar" level="project" />
     <orderEntry type="library" name="Gradle: com.github.PhilJay:MPAndroidChart:v3.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.bumptech.glide:glide:4.12.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.bumptech.glide:gifdecoder:4.12.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.exifinterface:exifinterface:1.2.0@aar" level="project" />
     <orderEntry type="library" name="Gradle: androidx.annotation:annotation-jvm:1.6.0" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.8.22" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22" level="project" />
@@ -264,5 +273,7 @@
     <orderEntry type="library" name="Gradle: io.grpc:grpc-protobuf-lite:1.57.2" level="project" />
     <orderEntry type="library" name="Gradle: com.google.protobuf:protobuf-javalite:3.22.3" level="project" />
     <orderEntry type="library" name="Gradle: io.grpc:grpc-stub:1.57.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.bumptech.glide:disklrucache:4.12.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.bumptech.glide:annotations:4.12.0" level="project" />
   </component>
 </module>

--- a/.idea/modules/app/Fire.app.unitTest.iml
+++ b/.idea/modules/app/Fire.app.unitTest.iml
@@ -26,6 +26,7 @@
           <stringArguments>
             <stringArg name="classpath">
               <args>
+                <arg>$MODULE_DIR$/../../../app/build/intermediates/compile_and_runtime_not_namespaced_r_class_jar/debug/R.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/26ee284f0d785bc799c033095622bd4f/transformed/viewbinding-8.2.2-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/2e6aabd2efec891653a5025d2f4191ca/transformed/firebase-firestore-ktx-24.11.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/741112277b4af0f9dd5ca454ad1b5eec/transformed/firebase-auth-22.3.1-api.jar</arg>
@@ -36,6 +37,7 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/916636a47deeb28de6003366496bb56d/transformed/firebase-common-ktx-20.4.3-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/c335fcb578d570b3c6ca0ca4e6be2ce3/transformed/material-1.11.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/7beb2aed6497dc96efbf238f79154e02/transformed/appcompat-1.6.1-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/00ad3e956d33fc23225686917cab2a1a/transformed/glide-4.12.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/417108bf9d9d7a28bcc7adc3689c0517/transformed/viewpager2-1.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/f352bce2f37159593eeef06447a71fe2/transformed/play-services-measurement-21.6.1-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/9e71b40870b29a029f5bc6981e5f46e2/transformed/play-services-measurement-sdk-21.6.1-api.jar</arg>
@@ -99,6 +101,8 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/1f27220b47669781457de0d600849a5de0e89909/collection-1.1.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/122b951ff9afa2480c955dd2b0a97791/transformed/localbroadcastmanager-1.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/050daf9a7b0da4434ddf3f0373553b05/transformed/firebase-components-17.1.5-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/02287308a02fccbc0d63129d165d8f17/transformed/gifdecoder-4.12.0-api.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/49d9df8b8d05db1d51ac97f38f25ce96/transformed/exifinterface-1.2.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/8a3c38cf265786e10ae8ff6aa1a8f7f7/transformed/core-runtime-2.2.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.arch.core/core-common/2.2.0/5e1b8b81dfd5f52c56a8d53b18ca759c19a301f3/core-common-2.2.0.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/androidx.concurrent/concurrent-futures/1.1.0/50b7fb98350d5f42a4e49704b03278542293ba48/concurrent-futures-1.1.0.jar</arg>
@@ -129,6 +133,8 @@
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/transforms-3/3901f4fa07ea3c00c2c1e736209f9f83/transformed/protolite-well-known-types-18.0.0-api.jar</arg>
                 <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.google.protobuf/protobuf-javalite/3.22.3/7df7200bce0ff77dc66dd063df79ff74c6114bfc/protobuf-javalite-3.22.3.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.github.bumptech.glide/disklrucache/4.12.0/6d44c9103551e3ff51f00ac26077c143a8fb74f9/disklrucache-4.12.0.jar</arg>
+                <arg>$USER_HOME$/Documents/GitHub/EGID_Android/.gradle/caches/modules-2/files-2.1/com.github.bumptech.glide/annotations/4.12.0/298d793db124809d74ad9a90de5eddc408898c84/annotations-4.12.0.jar</arg>
                 <arg>$USER_HOME$/AppData/Local/Android/Sdk/platforms/android-34/android.jar</arg>
                 <arg>$USER_HOME$/AppData/Local/Android/Sdk/build-tools/34.0.0/core-lambda-stubs.jar</arg>
               </args>
@@ -237,6 +243,9 @@
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.lifecycle:lifecycle-livedata-ktx:2.7.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.github.PhilJay:MPAndroidChart:v3.1.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:glide:4.12.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:gifdecoder:4.12.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.exifinterface:exifinterface:1.2.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.annotation:annotation-jvm:1.6.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.8.22" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22" level="project" />
@@ -266,6 +275,8 @@
     <orderEntry type="library" scope="TEST" name="Gradle: io.grpc:grpc-protobuf-lite:1.57.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.google.protobuf:protobuf-javalite:3.22.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: io.grpc:grpc-stub:1.57.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:disklrucache:4.12.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.github.bumptech.glide:annotations:4.12.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.13.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.7.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Permission for Camera -->
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+
+    <!-- Permissions for reading and writing to storage -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -13,7 +20,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Fire"
-        tools:targetApi="31"> 
+        tools:targetApi="31">
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.example.fire.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
         <activity
             android:name=".MainActivity"
@@ -54,6 +71,7 @@
         <activity android:name=".Diet6Activity"/>
         <activity android:name=".ResultsActivity"/>
         <activity android:name=".ReportActivity"/>
+        <activity android:name=".DBHelper"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/fire/AddChildActivity.kt
+++ b/app/src/main/java/com/example/fire/AddChildActivity.kt
@@ -1,17 +1,33 @@
 package com.example.fire
 
+import android.Manifest
 import android.content.Intent
+import android.content.DialogInterface
 import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
-import android.widget.AutoCompleteTextView
+import android.os.Environment
+import android.provider.MediaStore
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ImageView
 import android.widget.Toast
+import android.widget.AutoCompleteTextView
 import android.widget.ArrayAdapter
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.*
 
 class AddChildActivity : AppCompatActivity() {
     private lateinit var firstNameEditText: EditText
@@ -20,6 +36,13 @@ class AddChildActivity : AppCompatActivity() {
     private lateinit var genderInput: AutoCompleteTextView
     private lateinit var dietInput: AutoCompleteTextView
     private lateinit var saveButton: Button
+    private lateinit var pictureButton: Button
+    private lateinit var imageView: ImageView
+    private var imageUri: Uri? = null
+    private var currentPhotoPath: String = ""
+    private lateinit var takePictureLauncher: ActivityResultLauncher<Uri>
+    private lateinit var pickImageFromGalleryLauncher: ActivityResultLauncher<String>
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
     private val firebaseAuth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
     private var childId: String? = null // Used for edit mode
 
@@ -33,11 +56,19 @@ class AddChildActivity : AppCompatActivity() {
         genderInput = findViewById(R.id.GenderInputFields)
         dietInput = findViewById(R.id.DietInputFields)
         saveButton = findViewById(R.id.saveButton)
+        pictureButton = findViewById(R.id.button)
+        imageView = findViewById(R.id.imageView)
+
+        initLaunchers()
 
         // Check if in edit mode and if so, fetch and populate child data
         childId = intent.getStringExtra("childId")
         if (childId != null) {
             fetchAndPopulateChildData(childId!!)
+        }
+
+        pictureButton.setOnClickListener {
+            showImagePickDialog()
         }
 
         saveButton.setOnClickListener {
@@ -50,11 +81,36 @@ class AddChildActivity : AppCompatActivity() {
 
         setupDropdownMenus()
 
+        requestPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                // Call the method that was initially intended
+                dispatchTakePictureIntent()
+            } else {
+                Toast.makeText(this, "Permission is needed to proceed", Toast.LENGTH_SHORT).show()
+            }
+        }
     }
+
     override fun onResume() {
         super.onResume()
-        // Setup dropdown menus again to ensure they're always ready
         setupDropdownMenus()
+    }
+
+    private fun initLaunchers() {
+        takePictureLauncher = registerForActivityResult(ActivityResultContracts.TakePicture()) { isSuccess ->
+            if (isSuccess) {
+                imageView.setImageURI(imageUri)
+                saveImageInfoToDatabase()
+            }
+        }
+
+        pickImageFromGalleryLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            uri?.let {
+                imageView.setImageURI(uri)
+                imageUri = uri
+                saveImageInfoToDatabase()
+            }
+        }
     }
 
     private fun fetchAndPopulateChildData(childId: String) {
@@ -66,9 +122,6 @@ class AddChildActivity : AppCompatActivity() {
                     birthDateEditText.setText(document.getString("birthDate"))
                     genderInput.setText(document.getString("gender"))
                     dietInput.setText(document.getString("diet"))
-
-                    setupDropdownMenus()
-                    // Populate other fields as necessary
                 } else {
                     Toast.makeText(this, "Child not found.", Toast.LENGTH_SHORT).show()
                 }
@@ -90,19 +143,14 @@ class AddChildActivity : AppCompatActivity() {
 
         Firebase.firestore.collection("Children").add(userMap)
             .addOnSuccessListener { documentReference ->
-                // The new child's ID is obtained from the DocumentReference object
                 val newChildId = documentReference.id
-
-                // Here you would call saveCurrentChildId(newChildId) to save the ID to SharedPreferences
                 saveCurrentChildId(newChildId)
-
                 Toast.makeText(this, "Child added successfully", Toast.LENGTH_SHORT).show()
                 goToNextActivity()
             }
             .addOnFailureListener { e ->
                 Toast.makeText(this, "Failed to add child: ${e.message}", Toast.LENGTH_SHORT).show()
             }
-
     }
 
     private fun updateChildInfo() {
@@ -115,8 +163,8 @@ class AddChildActivity : AppCompatActivity() {
             "parentUserId" to firebaseAuth.currentUser?.uid
         )
 
-        childId?.let {
-            Firebase.firestore.collection("Children").document(it).set(userMap)
+        childId?.let { id ->
+            Firebase.firestore.collection("Children").document(id).set(userMap)
                 .addOnSuccessListener {
                     Toast.makeText(this, "Child updated successfully", Toast.LENGTH_SHORT).show()
                     goToNextActivity()
@@ -128,29 +176,23 @@ class AddChildActivity : AppCompatActivity() {
     }
 
     private fun saveCurrentChildId(childId: String) {
-        // Here, 'this' refers to the AddChildActivity instance, which is a Context object.
-        val sharedPreferences = this.getSharedPreferences("AppPreferences", Context.MODE_PRIVATE)
+        val sharedPreferences = getSharedPreferences("AppPreferences", MODE_PRIVATE)
         with(sharedPreferences.edit()) {
             putString("CurrentChildId", childId)
             apply()
         }
     }
 
-
     private fun setupDropdownMenus() {
         val genderOptions = resources.getStringArray(R.array.gender_options)
         val genderAdapter = ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, genderOptions)
-        findViewById<AutoCompleteTextView>(R.id.GenderInputFields).apply {
-            setAdapter(genderAdapter)
-        }
+        genderInput.setAdapter(genderAdapter)
 
         val dietOptions = resources.getStringArray(R.array.diet_options)
         val dietAdapter = ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, dietOptions)
-        findViewById<AutoCompleteTextView>(R.id.DietInputFields).apply {
-            setAdapter(dietAdapter)
-        }
-
+        dietInput.setAdapter(dietAdapter)
     }
+
     private fun goToNextActivity() {
         val isFirstTimeUser = intent.getBooleanExtra("isFirstTimeUser", false)
         val nextActivityIntent = if (isFirstTimeUser) {
@@ -165,4 +207,148 @@ class AddChildActivity : AppCompatActivity() {
         }
         startActivity(nextActivityIntent)
     }
+
+    private fun showImagePickDialog() {
+        val options = arrayOf("Take Photo", "Choose from Gallery", "Cancel")
+        val builder = android.app.AlertDialog.Builder(this)
+        builder.setItems(options) { dialog, which ->
+            when (which) {
+                0 -> {
+                    // Check and request camera permission
+                    when {
+                        ContextCompat.checkSelfPermission(
+                            this,
+                            Manifest.permission.CAMERA
+                        ) == PackageManager.PERMISSION_GRANTED -> {
+                            // Permission is already granted
+                            dispatchTakePictureIntent()
+                        }
+                        else -> {
+                            // Request camera permission
+                            requestPermissionLauncher.launch(Manifest.permission.CAMERA)
+                        }
+                    }
+                }
+                1 -> {
+                    // Check and request read media image permission
+                    when {
+                        ContextCompat.checkSelfPermission(
+                            this,
+                            Manifest.permission.READ_MEDIA_IMAGES
+                        ) == PackageManager.PERMISSION_GRANTED -> {
+                            // Permission is already granted
+                            pickImageFromGallery()
+                        }
+                        else -> {
+                            // Request read media image permission
+                            requestPermissionLauncher.launch(Manifest.permission.READ_MEDIA_IMAGES)
+                        }
+                    }
+                }
+                2 -> {
+                    if (dialog is DialogInterface) {
+                        dialog.dismiss() // Correctly dismiss the dialog
+                    }
+                }
+            }
+        }
+
+        val dialog = builder.create() // Create the AlertDialog from the builder
+        dialog.show() // Show the dialog
+    }
+
+
+
+    private fun dispatchTakePictureIntent() {
+        Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { takePictureIntent ->
+            takePictureIntent.resolveActivity(packageManager)?.also {
+                val photoFile: File? = try {
+                    createImageFile()
+                } catch (ex: IOException) {
+                    Toast.makeText(this, "Photo file creation failed", Toast.LENGTH_SHORT).show()
+                    null
+                }
+                photoFile?.also {
+                    imageUri = FileProvider.getUriForFile(this, "com.example.fire.fileprovider", it)
+                    takePictureLauncher.launch(imageUri)
+                }
+            }
+        }
+    }
+
+    private fun pickImageFromGallery() {
+        pickImageFromGalleryLauncher.launch("image/*")
+    }
+
+    private fun createImageFile(): File {
+        val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+        val storageDir: File? = getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        return File.createTempFile("JPEG_${timeStamp}_", ".jpg", storageDir).apply {
+            currentPhotoPath = absolutePath
+        }
+    }
+
+    private fun saveImageInfoToDatabase() {
+        val imageName = imageUri?.lastPathSegment
+        val imageUrl = imageUri.toString()
+        val date = System.currentTimeMillis()
+
+        val userMap = hashMapOf(
+            "imageUri" to imageUrl,
+            "imageName" to imageName,
+            "date" to date
+        )
+
+        childId?.let { id ->
+            Firebase.firestore.collection("Children").document(id)
+                .collection("Images").add(userMap)
+                .addOnSuccessListener {
+                    Toast.makeText(this, "Image saved successfully", Toast.LENGTH_SHORT).show()
+                }
+                .addOnFailureListener { e ->
+                    Toast.makeText(this, "Failed to save image: ${e.message}", Toast.LENGTH_SHORT).show()
+                }
+        }
+    }
+    private fun checkPermissionsAndTakePicture() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.CAMERA), REQUEST_CAMERA_PERMISSION)
+        } else {
+            dispatchTakePictureIntent()
+        }
+    }
+
+    private fun checkPermissionsAndPickImage() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE), REQUEST_STORAGE_PERMISSION)
+        } else {
+            pickImageFromGallery()
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        when (requestCode) {
+            REQUEST_CAMERA_PERMISSION -> {
+                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    dispatchTakePictureIntent()
+                } else {
+                    Toast.makeText(this, "Camera permission is required to take pictures", Toast.LENGTH_SHORT).show()
+                }
+            }
+            REQUEST_STORAGE_PERMISSION -> {
+                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    pickImageFromGallery()
+                } else {
+                    Toast.makeText(this, "Storage permission is required to pick images", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val REQUEST_CAMERA_PERMISSION = 1
+        const val REQUEST_STORAGE_PERMISSION = 2
+    }
+
 }

--- a/app/src/main/java/com/example/fire/DBHelper.kt
+++ b/app/src/main/java/com/example/fire/DBHelper.kt
@@ -1,0 +1,91 @@
+package com.example.fire
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import android.provider.BaseColumns
+import android.content.ContentValues
+import java.util.*
+
+class DBHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+    companion object {
+        const val DATABASE_NAME = "Documents.db"
+        const val DATABASE_VERSION = 1
+
+        private const val SQL_CREATE_ENTRIES =
+            "CREATE TABLE ${DocumentEntry.TABLE_NAME} (" +
+                    "${BaseColumns._ID} INTEGER PRIMARY KEY," +
+                    "${DocumentEntry.COLUMN_NAME_CHILD_ID} TEXT," +
+                    "${DocumentEntry.COLUMN_NAME_TITLE} TEXT," +
+                    "${DocumentEntry.COLUMN_NAME_URL} TEXT," +
+                    "${DocumentEntry.COLUMN_NAME_TYPE} TEXT," +
+                    "${DocumentEntry.COLUMN_NAME_SIZE} INTEGER," +
+                    "${DocumentEntry.COLUMN_NAME_DATE} INTEGER," +
+                    "${DocumentEntry.COLUMN_NAME_THUMBNAIL} TEXT)"
+
+        private const val SQL_DELETE_ENTRIES = "DROP TABLE IF EXISTS ${DocumentEntry.TABLE_NAME}"
+    }
+
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(SQL_CREATE_ENTRIES)
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        db.execSQL(SQL_DELETE_ENTRIES)
+        onCreate(db)
+    }
+
+    fun insertDocument(childId: String, name: String, url: String, type: String, size: Long, date: Long, thumbnail: String?): Long {
+        val db = writableDatabase
+
+        val values = ContentValues().apply {
+            put(DocumentEntry.COLUMN_NAME_CHILD_ID, childId)
+            put(DocumentEntry.COLUMN_NAME_TITLE, name)
+            put(DocumentEntry.COLUMN_NAME_URL, url)
+            put(DocumentEntry.COLUMN_NAME_TYPE, type)
+            put(DocumentEntry.COLUMN_NAME_SIZE, size)
+            put(DocumentEntry.COLUMN_NAME_DATE, date)
+            put(DocumentEntry.COLUMN_NAME_THUMBNAIL, thumbnail)
+        }
+
+        return db.insert(DocumentEntry.TABLE_NAME, null, values)
+    }
+
+    fun getAllDocuments(childId: String): List<DocumentsActivity.Document> {
+        val documents = mutableListOf<DocumentsActivity.Document>()
+        val db = readableDatabase
+        val cursor = db.query(
+            DocumentEntry.TABLE_NAME,
+            null,
+            "${DocumentEntry.COLUMN_NAME_CHILD_ID} = ?",
+            arrayOf(childId),
+            null,
+            null,
+            null
+        )
+        cursor.use { c ->
+            while (c.moveToNext()) {
+                val name = c.getString(c.getColumnIndexOrThrow(DocumentEntry.COLUMN_NAME_TITLE))
+                val url = c.getString(c.getColumnIndexOrThrow(DocumentEntry.COLUMN_NAME_URL))
+                val type = c.getString(c.getColumnIndexOrThrow(DocumentEntry.COLUMN_NAME_TYPE))
+                val size = c.getLong(c.getColumnIndexOrThrow(DocumentEntry.COLUMN_NAME_SIZE))
+                val date = Date(c.getLong(c.getColumnIndexOrThrow(DocumentEntry.COLUMN_NAME_DATE)))
+                val thumbnail = c.getString(c.getColumnIndexOrThrow(DocumentEntry.COLUMN_NAME_THUMBNAIL))
+
+                documents.add(DocumentsActivity.Document(name, url, type, size, date, thumbnail))
+            }
+        }
+        return documents
+    }
+
+    object DocumentEntry : BaseColumns {
+        const val TABLE_NAME = "documents"
+        const val COLUMN_NAME_CHILD_ID = "childId"
+        const val COLUMN_NAME_TITLE = "title"
+        const val COLUMN_NAME_URL = "url"
+        const val COLUMN_NAME_TYPE = "type"
+        const val COLUMN_NAME_SIZE = "size"
+        const val COLUMN_NAME_DATE = "date"
+        const val COLUMN_NAME_THUMBNAIL = "thumbnail"
+    }
+}

--- a/app/src/main/java/com/example/fire/HomeActivity.kt
+++ b/app/src/main/java/com/example/fire/HomeActivity.kt
@@ -6,9 +6,11 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
+import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import com.bumptech.glide.Glide
 
 class HomeActivity : AppCompatActivity() {
 
@@ -20,6 +22,7 @@ class HomeActivity : AppCompatActivity() {
     private lateinit var eOEedButton: Button
     private lateinit var childNameTextView: TextView
     private lateinit var childDietTextView: TextView
+    private lateinit var childImageView: ImageView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,6 +46,7 @@ class HomeActivity : AppCompatActivity() {
         eOEedButton = findViewById(R.id.EOEedButton)
         childNameTextView = findViewById(R.id.childName)
         childDietTextView = findViewById(R.id.childDiet)
+        childImageView = findViewById(R.id.homeImage)
 
         profileButton.setOnClickListener {
             val intent = Intent(this, ProfilesActivity::class.java)
@@ -81,16 +85,17 @@ class HomeActivity : AppCompatActivity() {
     }
 
     private fun fetchAndDisplayChildData(childId: String) {
-        val db = Firebase.firestore
-        db.collection("Children").document(childId).get()
+        Firebase.firestore.collection("Children").document(childId).get()
             .addOnSuccessListener { document ->
                 if (document.exists()) {
                     val childName = document.getString("firstName") ?: "No Name"
                     val childDiet = document.getString("diet") ?: "No Diet Specified"
+                    val imageUrl = document.getString("imageUrl") ?: ""
 
                     // Update UI with child data
                     childNameTextView.text = childName
                     childDietTextView.text = childDiet
+                    Glide.with(this).load(imageUrl).into(childImageView)
                 } else {
                     Toast.makeText(this, "Child not found.", Toast.LENGTH_SHORT).show()
                 }

--- a/app/src/main/res/layout/activity_child_profile.xml
+++ b/app/src/main/res/layout/activity_child_profile.xml
@@ -124,7 +124,6 @@
         android:text="@string/ChangePicture"
         app:backgroundTint="#BFB8A8"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/imageView" />
 

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -35,23 +35,37 @@
 
     </androidx.appcompat.widget.Toolbar>
 
-    <com.github.mikephil.charting.charts.LineChart
-        android:id="@+id/lineChart"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/chartContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/toolbar"
-        app:layout_constraintBottom_toTopOf="@id/descriptionText"
+        android:layout_marginVertical="20dp"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        app:layout_constraintBottom_toTopOf="@+id/sendButton"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:background="#FFFFFF" />
+        app:layout_constraintEnd_toEndOf="parent">
 
-    <TextView
-        android:id="@+id/descriptionText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="16dp"
-        app:layout_constraintBottom_toTopOf="@id/sendButton"/>
+        <com.github.mikephil.charting.charts.LineChart
+            android:id="@+id/lineChart"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/descriptionText"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:background="#FFFFFF" />
 
+        <TextView
+            android:id="@+id/descriptionText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:background="#FFFFFF" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
     <Button
         android:id="@+id/sendButton"
         android:layout_width="200dp"

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path
+        name="external_files"
+        path="." />
+    <external-files-path
+        name="my_images"
+        path="Pictures/" />
+    <files-path
+        name="internal_files"
+        path="." />
+</paths>


### PR DESCRIPTION
The graph has been simplified and now includes dates along the x axis. The graph and symptoms can be saved, send, or printed. A sqlite database has been implemented to store documents unique to each childId. Images can be taken or uploaded from the device for each child. I wasn't able to test this fully as i am using an emulator but i was able to at least get the image folder to open.